### PR TITLE
minor msgs printing bug

### DIFF
--- a/src/armsgs.py
+++ b/src/armsgs.py
@@ -4,6 +4,7 @@ from textwrap import wrap as wraptext
 from inspect import currentframe, getouterframes
 from glob import glob
 
+
 class Messages:
     """
     Create coloured text for messages printed to screen.
@@ -47,6 +48,7 @@ class Messages:
         self._last_updated = last_updated
         self._version = version
         self._verbose = verbose
+        self.sciexp = None
         # Save the version of the code including last update information to the log file
         if self._log:
             self._log.write("------------------------------------------------------\n\n")
@@ -131,7 +133,7 @@ class Messages:
 
     def close(self):
         """
-        Close the log file before the code exits
+        Close the log file and QA PDFs before the code exits
         """
         # Close PDFs
         try:
@@ -161,13 +163,9 @@ class Messages:
         print >>sys.stderr, premsg+dbgmsg+msg
         if self._log:
             self._log.write(self.cleancolors(premsg+dbgmsg+msg)+"\n")
+        # Close PDFs and log file
         self.close()
-        # Close PDFs
-        try:
-            self.sciexp._qa.close()
-        except AttributeError:
-            pass
-        #
+        # Print command line usage
         if usage:
             self.usage(None)
         sys.exit()
@@ -222,18 +220,10 @@ class Messages:
             self._log.write(self.cleancolors(premsg+dbgmsg+msg)+"\n")
         return
 
-    def bug(self, msg, close_pdf=False):
+    def bug(self, msg):
         """
         Print a bug message
         """
-        # Close PDF?
-        if close_pdf:
-            tmsgs = get_logger()
-            try:
-                tmsgs.sciexp._qa.close()
-            except AttributeError:
-                pass
-        #
         dbgmsg = self.debugmessage()
         premsg = self._start + self._white_BK + "[BUG]     ::" + self._end + " "
         print >>sys.stderr, premsg+dbgmsg+msg

--- a/src/pypit.py
+++ b/src/pypit.py
@@ -227,6 +227,10 @@ if __name__ == "__main__":
                 line_no = str(traceback.tb_lineno(tb))
                 tb = tb.tb_next
             filename = filename.split('/')[-1]
-            initmsgs.bug("There appears to be a bug on Line " + line_no + " of " + filename + " with error:" +
-                         initmsgs.newline() + str(ev) + initmsgs.newline() +
-                         "---> please contact the authors", close_pdf=True)
+            if str(ev) != "":
+                initmsgs.bug("There appears to be a bug on Line " + line_no + " of " + filename + " with error:" +
+                             initmsgs.newline() + str(ev) + initmsgs.newline() +
+                             "---> please contact the authors")
+            # Get armsgs instance to terminate
+            from armsgs import get_logger
+            get_logger().close()


### PR DESCRIPTION
When an error is encountered, pypit prints an error message and (incorrectly) a bug message. The fix prints only the error message, and closes all open files with the armsgs.Messages.close() function.