### PR TITLE
Single Slit Trace Kludge

### DIFF
--- a/doc/tracing.rst
+++ b/doc/tracing.rst
@@ -1,0 +1,27 @@
+.. highlight:: rest
+
+*******
+Tracing
+*******
+
+This document will describe how the code traces the
+edges of slits.
+
+
+User Inputted Values
+====================
+
+If necessary, the user may define the edges of the slit(s)
+on each detector.  Currently this is only implemented for
+single slit (i.e. longslit) mode.  The syntax is to add a
+line to the .red file indicating the start and end of each
+slit on each detector in detector column units (as binned).
+
+For example, for the LRISr longslit with 2x2 binning, the
+following line will force the slit to be generated from
+columns 7-295 on the second detctor::
+
+    trace orders sng_slit [0,0,7,295]
+
+Because the 2nd value is 0, the code will be required to
+automatically find a slit on the first detector.

--- a/src/arload.py
+++ b/src/arload.py
@@ -42,7 +42,8 @@ def argflag_init():
     bfl = dict({'comb':dict({'method':None, 'rej_cosmicray':50.0, 'rej_lowhigh':[0,0], 'rej_level':[3.0,3.0], 'sat_pix':'reject', 'set_allrej':'median'}) })
     trc = dict({'comb':dict({'method':'weightmean', 'rej_cosmicray':50.0, 'rej_lowhigh':[0,0], 'rej_level':[3.0,3.0], 'sat_pix':'reject', 'set_allrej':'maxnonsat'}),
                 'disp':dict({'window':None, 'direction':None}),
-                'orders':dict({'tilts':'trace', 'pcatilt':[2,1,0], 'tiltorder':1, 'tiltdisporder':2, 'function':'polynomial', 'polyorder':2, 'diffpolyorder':2, 'fracignore':0.6, 'sigdetect':3.0, 'pca':[3,2,1,0,0,0], 'pcxpos':3, 'pcxneg':3}) })
+                'orders': dict({'tilts':'trace', 'pcatilt':[2,1,0], 'tiltorder':1, 'tiltdisporder':2, 'function':'polynomial', 'polyorder':2, 'diffpolyorder':2, 'fracignore':0.6, 'sigdetect':3.0, 'pca':[3,2,1,0,0,0], 'pcxpos':3, 'pcxneg':3,
+                                'sng_slit': []}) })
     arc = dict({'comb':dict({'method':'weightmean', 'rej_cosmicray':50.0, 'rej_lowhigh':[0,0], 'rej_level':[3.0,3.0], 'sat_pix':'reject', 'set_allrej':'maxnonsat'}),
                 'extract':dict({'binby':1.0}),
                 'load':dict({'extracted':False, 'calibrated':False}),

--- a/src/armlsd.py
+++ b/src/armlsd.py
@@ -75,7 +75,7 @@ def ARMLSD(argflag, spect, fitsdict, reuseMaster=False):
         msgs.info("Reducing file {0:s}, target {1:s}".format(fitsdict['filename'][scidx], slf._target_name))
         msgs.sciexp = slf  # For QA writing on exit, if nothing else.  Could write Masters too
         # Loop on Detectors
-        for kk in xrange(slf._spect['mosaic']['ndet']):
+        for kk in xrange(1,slf._spect['mosaic']['ndet']):
             det = kk + 1  # Detectors indexed from 1
             ###############
             # Get amplifier sections

--- a/src/artrace.py
+++ b/src/artrace.py
@@ -317,12 +317,22 @@ def trace_orders(slf, mstrace, det, pcadesc="", maskBadRows=False, singleSlit=Fa
     if singleSlit:
         edgearr = np.zeros(binarr.shape, dtype=np.int)
         detect = True
+        # Add a user-defined slit?
+        # Syntax is a list of values, 2 per detector that define the slit
+        # according to column values.  The 2nd value (for the right edge)
+        # must be >0 to be applied.  Example for LRISr [-1, -1, 7, 295]
+        # which means the code skips user-definition for the first detector
+        # but adds one for the 2nd.
         if len(slf._argflag['trace']['orders']['sng_slit']) > 0:
-            redge = (det-1)*2+1
+            ledge, redge = (det-1)*2, (det-1)*2+1
             if slf._argflag['trace']['orders']['sng_slit'][redge] > 0:
-                msgs.warn("Using input slit edges. Better know what you are doing..")
-                edgearr[:, slf._argflag['trace']['orders']['sng_slit'][(det-1)*2]] = -1
-                edgearr[:, slf._argflag['trace']['orders']['sng_slit'][(det-1)*2+1]] = +1
+                msgs.warn("Using input slit edges on detector {:d}: [{:g},{:g}]".format(
+                        det,
+                        slf._argflag['trace']['orders']['sng_slit'][ledge],
+                        slf._argflag['trace']['orders']['sng_slit'][redge]))
+                msgs.warn("Better know what you are doing!")
+                edgearr[:, slf._argflag['trace']['orders']['sng_slit'][ledge]] = -1
+                edgearr[:, slf._argflag['trace']['orders']['sng_slit'][redge]] = +1
                 detect = False
         if detect:
             msgs.info("Detecting slit edges")

--- a/src/artrace.py
+++ b/src/artrace.py
@@ -315,15 +315,24 @@ def trace_orders(slf, mstrace, det, pcadesc="", maskBadRows=False, singleSlit=Fa
     msgs.info("Detecting order edges")
     #debugger.set_trace()
     if singleSlit:
-        msgs.info("Detecting slit edges")
-        filt = ndimage.sobel(binarr, axis=1, mode='constant')
-        msgs.info("Applying bad pixel mask")
-        filt *= (1.0-binbpx)  # Apply to the old detection algorithm
-        amin = np.argmin(filt, axis=1)
-        amax = np.argmax(filt, axis=1)
         edgearr = np.zeros(binarr.shape, dtype=np.int)
-        edgearr[np.arange(edgearr.shape[0]), amin] = +1
-        edgearr[np.arange(edgearr.shape[0]), amax] = -1
+        detect = True
+        if len(slf._argflag['trace']['orders']['sng_slit']) > 0:
+            redge = (det-1)*2+1
+            if slf._argflag['trace']['orders']['sng_slit'][redge] > 0:
+                msgs.warn("Using input slit edges. Better know what you are doing..")
+                edgearr[:, slf._argflag['trace']['orders']['sng_slit'][(det-1)*2]] = -1
+                edgearr[:, slf._argflag['trace']['orders']['sng_slit'][(det-1)*2+1]] = +1
+                detect = False
+        if detect:
+            msgs.info("Detecting slit edges")
+            filt = ndimage.sobel(binarr, axis=1, mode='constant')
+            msgs.info("Applying bad pixel mask")
+            filt *= (1.0-binbpx)  # Apply to the old detection algorithm
+            amin = np.argmin(filt, axis=1)
+            amax = np.argmax(filt, axis=1)
+            edgearr[np.arange(edgearr.shape[0]), amin] = +1
+            edgearr[np.arange(edgearr.shape[0]), amax] = -1
         # Even better would be to fit the filt/sqrt(abs(binarr)) array with a Gaussian near the maximum in each column
     else:
         ######


### PR DESCRIPTION
Implementing a simplistic way for the user to define the
slit edges of a long slit.

Am stymied by the LRISr dome flat.  In some cases, it spikes
on both sides of the slit to mimic mini slits.  Any standard 
edge-detecting algorithm will struggle...