### PR TITLE
Slit Trace Fix

### DIFF
--- a/src/ararc.py
+++ b/src/ararc.py
@@ -409,7 +409,7 @@ def simple_calib(slf, det, get_poly=False):
 
     # Final fit (originals can now be rejected)
     fmin, fmax = 0., 1. 
-    xfit, yfit = tcent[ifit]/slf._msarc[det-1].shape[0], all_ids[ifit]
+    xfit, yfit = tcent[ifit]/(slf._msarc[det-1].shape[0]-1), all_ids[ifit]
     mask, fit = arutils.robust_polyfit(xfit, yfit, n_order, function=aparm['func'], sigma=aparm['nsig_rej_final'], minv=fmin, maxv=fmax)#, debug=True)
     irej = np.where(mask==1)[0]
     if len(irej) > 0:

--- a/src/armlsd.py
+++ b/src/armlsd.py
@@ -75,7 +75,7 @@ def ARMLSD(argflag, spect, fitsdict, reuseMaster=False):
         msgs.info("Reducing file {0:s}, target {1:s}".format(fitsdict['filename'][scidx], slf._target_name))
         msgs.sciexp = slf  # For QA writing on exit, if nothing else.  Could write Masters too
         # Loop on Detectors
-        for kk in xrange(1,slf._spect['mosaic']['ndet']):
+        for kk in xrange(slf._spect['mosaic']['ndet']):
             det = kk + 1  # Detectors indexed from 1
             ###############
             # Get amplifier sections

--- a/src/artrace.py
+++ b/src/artrace.py
@@ -1209,7 +1209,13 @@ def model_tilt(slf, det, msarc, censpec=None, maskval=-999999.9,
         elif slf._argflag['trace']['orders']['tilts'].lower() == "spca":
              xspl = np.linspace(0.0, 1.0, msarc.shape[1])
              #yspl = np.append(0.0, np.append(arcdet[np.where(aduse)]/(msarc.shape[0]-1.0), 1.0))
-             yspl = np.append(0.0, np.append(polytilts[arcdet[np.where(aduse)],msarc.shape[1]/2],1.0))
+             adu = np.where(aduse)[0]
+             yspl = np.zeros(len(adu)+2)
+             yspl[-1] = 1.
+             for kk,iadu in enumerate(adu):
+                 yspl[kk+1] = polytilts[arcdet[iadu],ordcen[iadu]]
+             #yspl = np.append(0.0, np.append(polytilts[arcdet[np.where(aduse)],msarc.shape[1]/2],1.0))
+             #
              zspl = np.zeros((msarc.shape[1], np.sum(aduse)+2))
              zspl[:, 1:-1] = polytilts[arcdet[np.where(aduse)[0]], :].T
              zspl[:, 0] = zspl[:, 1] + polytilts[0, :] - polytilts[arcdet[np.where(aduse)[0][0]], :]

--- a/src/artrace.py
+++ b/src/artrace.py
@@ -1226,15 +1226,12 @@ def model_tilt(slf, det, msarc, censpec=None, maskval=-999999.9,
                 plt.show()
                 debugger.set_trace()
         elif slf._argflag['trace']['orders']['tilts'].lower() == "spca":
+             # Slit position
              xspl = np.linspace(0.0, 1.0, msarc.shape[1])
-             #yspl = np.append(0.0, np.append(arcdet[np.where(aduse)]/(msarc.shape[0]-1.0), 1.0))
-             adu = np.where(aduse)[0]
-             yspl = np.zeros(len(adu)+2)
-             yspl[-1] = 1.
-             for kk,iadu in enumerate(adu):
-                 yspl[kk+1] = polytilts[arcdet[iadu],ordcen[iadu]]
-             #yspl = np.append(0.0, np.append(polytilts[arcdet[np.where(aduse)],msarc.shape[1]/2],1.0))
-             #
+             # Trace positions down center of the order
+             ycen = np.diag(polytilts[arcdet[np.where(aduse)], ordcen[arcdet[np.where(aduse)]]])
+             yspl = np.append(0.0, np.append(ycen, 1.0))
+             # Trace positions as measured+modeled
              zspl = np.zeros((msarc.shape[1], np.sum(aduse)+2))
              zspl[:, 1:-1] = polytilts[arcdet[np.where(aduse)[0]], :].T
              zspl[:, 0] = zspl[:, 1] + polytilts[0, :] - polytilts[arcdet[np.where(aduse)[0][0]], :]


### PR DESCRIPTION
Fix to spca definition for yspl.  Now uses ordcen which 
is proper as this is where the Wavelength solution is generated.