### PR TITLE
Arc offset

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -28,6 +28,7 @@ Contents
    running
    outputs
    scripts
+   wave_calib
    api
 
 

--- a/doc/wave_calib.rst
+++ b/doc/wave_calib.rst
@@ -33,6 +33,28 @@ XeI     4000-12000  14 April 2016
 ZnI     2900-8000   2 May 2016
 ======  ==========  =============
 
+By-Hand Calibration
+===================
+
+If the automatic algorithm is faililng (heaven forbid), you
+can input a set of pixel, wavelength values as a crutch in
+your .pypit setup file.  Here is the recommended approach:
+
+#. Run PYPIT with --debug_arc on. This will force the code to stop inside ararc.py
+#. Print the pixel values to the screen
+
+   *  (Pdb) tcent
+
+#. Plot the arc spectrum.
+
+   *  (Pdb) plt.plot(yprep)
+   *  (Pdb) plt.show()
+
+#. Compare that spectrum with a known one and ID a few lines.  Write down.  Better be using vacuum wavelengths
+#. Add pixel values and wavelengths to your .pypit file, e.g.
+
+   * arc calibrate id_pix 872.062,902.7719,1931.0048,2452.620,3365.25658,3887.125
+   * arc calibrate id_wave 3248.4769,3274.905,4159.763,4610.656,5402.0634,5854.110
 
 Validation
 ==========

--- a/doc/wave_calib.rst
+++ b/doc/wave_calib.rst
@@ -36,8 +36,9 @@ ZnI     2900-8000   2 May 2016
 By-Hand Calibration
 ===================
 
-If the automatic algorithm is faililng (heaven forbid), you
-can input a set of pixel, wavelength values as a crutch in
+If the automatic algorithm is failing (heaven forbid; and you should
+probably raise an Issue on PYPIT if you are sure it isn't your fault),
+you can input a set of pixel, wavelength values as a crutch in
 your .pypit setup file.  Here is the recommended approach:
 
 #. Run PYPIT with --debug_arc on. This will force the code to stop inside ararc.py

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -305,6 +305,12 @@ def simple_calib(slf, det, get_poly=False):
             msgs.error("Need to give at least 5 pixel values!")
         #
         msgs.info("Using input lines to seed the wavelength solution")
+        # Calculate median offset
+        mdiff = [np.min(np.abs(tcent-pix)) for pix in
+                 slf._argflag['arc']['calibrate']['id_pix']]
+        med_poff = np.median(np.array(mdiff))
+        msgs.info("Will apply a median offset of {:g} pixels".format(med_poff))
+
         # Match input lines to observed spectrum
         nid = len(slf._argflag['arc']['calibrate']['id_pix'])
         idx_str = np.ones(nid).astype(int)
@@ -312,7 +318,7 @@ def simple_calib(slf, det, get_poly=False):
         idsion = np.array(['     ']*nid)
         gd_str = np.arange(nid).astype(int)
         for jj,pix in enumerate(slf._argflag['arc']['calibrate']['id_pix']):
-            diff = np.abs(tcent-pix)
+            diff = np.abs(tcent-pix-med_poff)
             if np.min(diff) > 2.:
                 debugger.set_trace()
                 msgs.error("No match with input pixel {:g}!".format(pix))

--- a/pypit/scripts/run_pypit.py
+++ b/pypit/scripts/run_pypit.py
@@ -41,6 +41,7 @@ def parser(options=None):
     parser.add_argument("-v", "--verbose", type=int, default=2, help="(2) Level of verbosity (0-2)")
     parser.add_argument("-m", "--use_masters", default=False, action='store_true', help="Load previously generated MasterFrames")
     parser.add_argument("-d", "--develop", default=False, action='store_true', help="Turn develop debugging on")
+    parser.add_argument("--debug_arc", default=False, action='store_true', help="Turn wavelength/arc debugging on")
     #parser.add_argument("-q", "--quick", default=False, help="Quick reduction", action="store_true")
     #parser.add_argument("-c", "--cpus", default=False, help="Number of CPUs for parallel processing", action="store_true")
     #parser.print_help()
@@ -68,29 +69,10 @@ def main(args):
     qck = False
     cpu = 1
     #vrb = 2
-    #use_masters = False
-
-    #if len(sys.argv) < 2:
-    #    initmsgs.usage(None)
 
     # Load options from command line
-    """
-        for o, a in opt:
-            elif o in ('-q', '--quick'):
-                qck = True
-            elif o in ('-c', '--cpus'):
-                cpu = int(a)
-            elif o in ('-v', '--verbose'):
-                vrb = int(a)
-            elif o in ('-m', '--use_masters'):
-                use_masters=True
-            elif o in ('-d', '--develop'):
-                debug['develop'] = True
-        red = arg[0]
-    except getopt.GetoptError, err:
-        initmsgs.error(err.msg, usage=True)
-    """
     debug['develop'] = debug['develop'] or args.develop
+    debug['arc'] = debug['arc'] or args.debug_arc
     splitnm = os.path.splitext(args.pypit_file)
     if splitnm[1] != '.pypit':
         initmsgs.error("Bad extension for PYPIT reduction file."+initmsgs.newline()+".pypit is required")

--- a/pypit/tests/test_ararc.py
+++ b/pypit/tests/test_ararc.py
@@ -1,0 +1,35 @@
+# Module to run tests on ararclines
+
+
+import numpy as np
+import pytest
+
+from pypit import pyputils
+msgs = pyputils.get_dummy_logger()
+from pypit import ararc as pyarc
+from pypit import arutils as arut
+
+#def data_path(filename):
+#    data_dir = os.path.join(os.path.dirname(__file__), 'files')
+#    return os.path.join(data_dir, filename)
+
+
+def test_setup_param():
+    """ Run the parameter setup script
+    Returns
+    -------
+
+    """
+    # Load
+    # Dummy self
+    slf = arut.dummy_self()
+    slf._argflag['run']['spectrograph'] = 'kast_blue'
+    slf._spect['arc'] = {}
+    slf._spect['arc']['index'] = [[0]]
+    fitsdict = {}
+    fitsdict["disperser"] = ['600/4310']
+    fitsdict["binning"] = [[None]]
+    # Run
+    arcparm = pyarc.setup_param(slf, 0, 1, fitsdict)
+    for key in ['llist','disp','wvmnx']:
+        assert key in arcparm


### PR DESCRIPTION
Adds a simple calculation of offset between input pixel centroids for the arc lines and measured.
Most useful for multiple detectors (e.g. LRIS).  Might also work as a poor auto ID.

Added test and docs

Tests are failing arline_id plot on Travis but pass on my laptop.

Address Issue #110 

