### PR TITLE
Removed dispaxis/dispdir

### DIFF
--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -66,8 +66,8 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     else:
         ordcen = slf.GetFrame(slf._pixcen, det)
     if censpec is None:
-        #pixcen = np.arange(msarc.shape[slf._dispaxis], dtype=np.int)
-        #ordcen = (msarc.shape[1-slf._dispaxis]/2)*np.ones(msarc.shape[slf._dispaxis],dtype=np.int)
+        #pixcen = np.arange(msarc.shape[0], dtype=np.int)
+        #ordcen = (msarc.shape[1]/2)*np.ones(msarc.shape[0],dtype=np.int)
         #if len(ordcen.shape) != 1: msgs.error("The function artrace.model_tilt should only be used for"+msgs.newline()+"a single spectrum (or order)")
         #ordcen = ordcen.reshape((ordcen.shape[0],1))
         msgs.work("No orders being masked at the moment")
@@ -82,7 +82,7 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
         ordwid = 0.5*np.abs(slf._lordloc[det-1] - slf._rordloc[det-1])
         msgs.info("Generating a mask of arc line saturation streaks")
         satmask = arcyarc.saturation_mask(msarc, slf._nonlinear[det-1])
-        satsnd = arcyarc.order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int), slf._dispaxis)
+        satsnd = arcyarc.order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int))
     else:
         satsnd = np.zeros_like(ordcen)
     # Detect the location of the arc lines

--- a/pypit/arcyarc.pyx
+++ b/pypit/arcyarc.pyx
@@ -1879,13 +1879,12 @@ def nbrightest(np.ndarray[DTYPE_t, ndim=2] pixels not None,
 @cython.boundscheck(False)
 def order_saturation(np.ndarray[ITYPE_t, ndim=2] satmask not None,
                     np.ndarray[ITYPE_t, ndim=2] ordcen not None,
-                    np.ndarray[ITYPE_t, ndim=2] ordwid not None,
-                    int dispdir):
+                    np.ndarray[ITYPE_t, ndim=2] ordwid not None):
 
     cdef int sz_x, sz_o, sz_y, x, y, o
     cdef int flag, xmin, xmax
-    sz_x = satmask.shape[1-dispdir]
-    sz_y = satmask.shape[dispdir]
+    sz_x = satmask.shape[1]
+    sz_y = satmask.shape[0]
     sz_o = ordcen.shape[1]
 
     cdef np.ndarray[ITYPE_t, ndim=2] ordsat = np.zeros((sz_y,sz_o), dtype=ITYPE)
@@ -1897,14 +1896,9 @@ def order_saturation(np.ndarray[ITYPE_t, ndim=2] satmask not None,
             if xmin < 0: xmin = 0
             if xmax >= sz_x: xmax=sz_x
             for x in range(xmin,xmax):
-                if dispdir == 0:
-                    if satmask[y,x] == 1:
-                        ordsat[y,o] = 1
-                        break
-                else:
-                    if satmask[x,y] == 1:
-                        ordsat[y,o] = 1
-                        break
+                if satmask[y,x] == 1:
+                    ordsat[y,o] = 1
+                    break
     return ordsat
 
 #######

--- a/pypit/arcyproc.pyx
+++ b/pypit/arcyproc.pyx
@@ -152,7 +152,7 @@ def combine_nrmflat(np.ndarray[DTYPE_t, ndim=2] msframe not None,
                     np.ndarray[ITYPE_t, ndim=1] pixcen not None,
                     np.ndarray[ITYPE_t, ndim=1] pixledg not None,
                     np.ndarray[ITYPE_t, ndim=1] pixredg not None,
-                    int pixwid, double maskval, int dispaxis):
+                    int pixwid, double maskval):
     """
     Replace the master normalized flat frame values with the values for this
     order. If a value already exists in the master frame take the average
@@ -163,8 +163,8 @@ def combine_nrmflat(np.ndarray[DTYPE_t, ndim=2] msframe not None,
     cdef int yidx, ymin, ymax, sz_p
     cdef int shift = pixwid/2
 
-    sz_x  = frame.shape[dispaxis]
-    sz_y  = frame.shape[1-dispaxis]
+    sz_x  = frame.shape[0]
+    sz_y  = frame.shape[1]
     sz_p = 2*shift+1
 
     for x in range(0,sz_x):
@@ -178,16 +178,10 @@ def combine_nrmflat(np.ndarray[DTYPE_t, ndim=2] msframe not None,
             if pixredg[x] <= 0 or pixledg[x] >= sz_y-1 or yidx < 0 or yidx >= sz_y:
                 continue
             else:
-                if dispaxis == 0:
-                    if msframe[x,yidx] != maskval:
-                        msframe[x,yidx] += frame[x,yidx]
-                        msframe[x,yidx] /= 2.0
-                    else: msframe[x,yidx] = frame[x,yidx]
-                else:
-                    if msframe[yidx,x] != maskval:
-                        msframe[yidx,x] += frame[yidx,x]
-                        msframe[yidx,x] /= 2.0
-                    else: msframe[yidx,x] = frame[yidx,x]
+                if msframe[x,yidx] != maskval:
+                    msframe[x,yidx] += frame[x,yidx]
+                    msframe[x,yidx] /= 2.0
+                else: msframe[x,yidx] = frame[x,yidx]
     return msframe
 
 
@@ -436,8 +430,7 @@ def prepare_bgmodel(np.ndarray[DTYPE_t, ndim=2] arcfr not None,
                     np.ndarray[DTYPE_t, ndim=1] dtrc not None,
                     np.ndarray[DTYPE_t, ndim=1] scen not None,
                     np.ndarray[ITYPE_t, ndim=1] dpix not None,
-                    np.ndarray[ITYPE_t, ndim=1] spix not None,
-                    int dispdir):
+                    np.ndarray[ITYPE_t, ndim=1] spix not None):
 
     cdef int p, b, donebl, donetl
     cdef int sz_p, sz_b
@@ -452,16 +445,10 @@ def prepare_bgmodel(np.ndarray[DTYPE_t, ndim=2] arcfr not None,
 
     for p in range(sz_p):
         # get the bottom-left (i.e. the origin) and top-left corner of the pixel
-        if dispdir == 0:
-            dbl = pixmap[dpix[p],spix[p],0] - 0.5*pixmap[dpix[p],spix[p],2]
-            sbl = pixmap[dpix[p],spix[p],1] - 0.5*pixmap[dpix[p],spix[p],3]
-            dtl = pixmap[dpix[p],spix[p],0] + 0.5*pixmap[dpix[p],spix[p],2]
-            stl = pixmap[dpix[p],spix[p],1] + 0.5*pixmap[dpix[p],spix[p],3]
-        else:
-            dbl = pixmap[spix[p],dpix[p],1] - 0.5*pixmap[spix[p],dpix[p],3]
-            sbl = pixmap[spix[p],dpix[p],0] - 0.5*pixmap[spix[p],dpix[p],2]
-            dtl = pixmap[spix[p],dpix[p],1] + 0.5*pixmap[spix[p],dpix[p],3]
-            stl = pixmap[spix[p],dpix[p],0] + 0.5*pixmap[spix[p],dpix[p],2]
+        dbl = pixmap[dpix[p],spix[p],0] - 0.5*pixmap[dpix[p],spix[p],2]
+        sbl = pixmap[dpix[p],spix[p],1] - 0.5*pixmap[dpix[p],spix[p],3]
+        dtl = pixmap[dpix[p],spix[p],0] + 0.5*pixmap[dpix[p],spix[p],2]
+        stl = pixmap[dpix[p],spix[p],1] + 0.5*pixmap[dpix[p],spix[p],3]
         donebl = 0
         donetl = 0
         for b in range(1,sz_b):
@@ -496,10 +483,7 @@ def prepare_bgmodel(np.ndarray[DTYPE_t, ndim=2] arcfr not None,
         cv = (lb-la)/vb
         svb = csqrt(sva*sva + 1.0) / (sva*sva - 1.0)
         # Finally, calculate the appropriate value for xfit and yfit
-        if dispdir == 0:
-            xfit[p] = la + 0.5*cv*svb*(pixmap[dpix[p],spix[p],2] + sva*pixmap[dpix[p],spix[p],3])
-        else:
-            xfit[p] = la + 0.5*cv*svb*(pixmap[spix[p],dpix[p],3] + sva*pixmap[spix[p],dpix[p],2])
+        xfit[p] = la + 0.5*cv*svb*(pixmap[dpix[p],spix[p],2] + sva*pixmap[dpix[p],spix[p],3])
     return xfit
 
 #######

--- a/pypit/arcytrace.pyx
+++ b/pypit/arcytrace.pyx
@@ -568,10 +568,8 @@ def close_slits(np.ndarray[DTYPE_t, ndim=2] trframe not None,
 #######
 
 @cython.boundscheck(False)
-def detect_edges(np.ndarray[DTYPE_t, ndim=2] array not None,
-                int dispdir):
+def detect_edges(np.ndarray[DTYPE_t, ndim=2] array not None):
     # array     : trace frame
-    # dispdir   : (0 or 1), is the direction of dispersion (0/1 is along a row/column)
 
     cdef int sz_x, sz_y
     cdef int x, y
@@ -579,8 +577,8 @@ def detect_edges(np.ndarray[DTYPE_t, ndim=2] array not None,
     cdef double difvl, difvc, difvr
     cdef int lcnt, rcnt
 
-    sz_x = array.shape[dispdir]
-    sz_y = array.shape[1-dispdir]
+    sz_x = array.shape[0]
+    sz_y = array.shape[1]
 
     # Set up the array which marks detections
     cdef np.ndarray[ITYPE_t, ndim=2] edgdet = np.zeros((array.shape[0],array.shape[1]), dtype=ITYPE)
@@ -590,7 +588,7 @@ def detect_edges(np.ndarray[DTYPE_t, ndim=2] array not None,
     cdef np.ndarray[DTYPE_t, ndim=2] medarr = np.zeros((sz_y,medsum), dtype=DTYPE)
 
     for x in range(ms,sz_x-ms):
-        median_ed(array,medarr,dispdir,x,ms)
+        median_ed(array,medarr,x,ms)
         cl = 0
         dl = 0
         cr = 0
@@ -628,17 +626,11 @@ def detect_edges(np.ndarray[DTYPE_t, ndim=2] array not None,
                     dr = 0
             if dl == 4:
                 # A left edge detection!
-                if dispdir == 0:
-                    edgdet[x,tl] = -1
-                else:
-                    edgdet[tl,x] = -1
+                edgdet[x,tl] = -1
                 dl = 0
             if dr == 4:
                 # A right edge detection!
-                if dispdir == 0:
-                    edgdet[x,tr] = 1
-                else:
-                    edgdet[tr,x] = 1
+                edgdet[x,tr] = 1
                 dr = 0
     return edgdet
 
@@ -894,15 +886,15 @@ def find_shift(np.ndarray[DTYPE_t, ndim=2] mstrace not None,
                 np.ndarray[DTYPE_t, ndim=1] minarr not None,
                 np.ndarray[ITYPE_t, ndim=1] lopos not None,
                 np.ndarray[ITYPE_t, ndim=1] diffarr not None,
-                int numsrch, int dispdir):
+                int numsrch):
 
     cdef int sz_x, sz_y
     cdef int x, y, s
     cdef int shift = 0
     cdef double cnts, npts, maxcnts
 
-    sz_x = mstrace.shape[dispdir]
-    sz_y = mstrace.shape[1-dispdir]
+    sz_x = mstrace.shape[0]
+    sz_y = mstrace.shape[1]
 
     maxcnts = -999999.9
     shift = 0
@@ -915,10 +907,7 @@ def find_shift(np.ndarray[DTYPE_t, ndim=2] mstrace not None,
             if ymin < 0: ymin = 0
             elif ymax > sz_y: ymax = sz_y
             for y in range(ymin,ymax):
-                if dispdir == 0:
-                    cnts += (mstrace[x,y]-minarr[x])
-                else:
-                    cnts += (mstrace[y,x]-minarr[x])
+                cnts += (mstrace[x,y]-minarr[x])
                 npts += 1.0
         if npts == 0.0:
             continue
@@ -1004,15 +993,13 @@ def get_closest(np.ndarray[DTYPE_t, ndim=2] orderpx not None,
                     l+=1
     return clsdist
 
-#(orderpx,swlin,edgenby[trc,0],edgenby[trc,1])
 @cython.boundscheck(False)
 def get_edges(np.ndarray[DTYPE_t, ndim=2] array not None,
-                  double threshold, int srchspe, int srchspa, int dispdir):
+                  double threshold, int srchspe, int srchspa):
     # array     : trace frame
     # threshold : sigma detection threshold
     # srchspe   : Number of pixels to search along the spectral direction
     # srchspa   : Number of pixels to search along the spatial direction (must be an odd number)
-    # dispdir   : (0 or 1), is the direction of dispersion (0/1 is along a row/column)
 
     cdef int sz_x, sz_y
     cdef int x, y, i, j, k, l, nx, ny
@@ -1041,547 +1028,222 @@ def get_edges(np.ndarray[DTYPE_t, ndim=2] array not None,
         edgenby[i,0] = -999
         edgenby[i,1] = -999
 
-    if dispdir == 0: # If dispersion is along a row
-        for x in range(sz_x):
-            ival = -1
-            cval = -1
-            icnt = 0
-            dval = 0.0
-            for y in range(1,sz_y):
-                if array[x,y] == 0.0 or array[x,y-1] == 0.0: continue
-                difval = array[x,y]-array[x,y-1]
-                errval = array[x,y]+array[x,y-1]
-                if errval > 0.0:
-                    errval = csqrt(errval)
-                else:
-                    errval = csqrt(-errval)
-                if difval > 0.0:
-                    if dval < 0.0:
-                        if ival != -1 and icnt > 3: edgearr[x,ival] = -999
-                        ival = -1
-                        cval = -1
-                        icnt = 0
-                        dval = 0.0
-                    if difval/errval > threshold:
-                        if cval == -1:
-                            ival = y
-                            icnt = 1
-                            dval = difval
-                        elif cval+1 == y:
-                            if difval > dval:
-                                dval = difval
-                                ival = y
-                            icnt += 1
-                        else:
-                            if icnt > 3: edgearr[x,ival] = 999
-                            ival = y
-                            icnt = 1
-                            dval = difval
-                        cval = y
-                    else:
-                        if cval != -1 and ival != -1 and icnt > 3:
-                            edgearr[x,ival] = 999
-                        cval = -1
-                        icnt = 0
-                        dval = 0.0
-                else:
-                    if dval > 0.0:
-                        if ival != -1 and icnt > 3: edgearr[x,ival] = 999
-                        ival = -1
-                        cval = -1
-                        icnt = 0
-                        dval = 0.0
-                    if -difval/errval > threshold:
-                        if cval == -1:
-                            ival = y
-                            icnt = 1
-                            dval = difval
-                        elif cval+1 == y:
-                            if difval < dval:
-                                dval = difval
-                                ival = y
-                            icnt += 1
-                        else:
-                            edgearr[x,ival] = -999
-                            ival = y
-                            icnt = 0
-                            dval = difval
-                        cval = y
-                    else:
-                        if cval != -1 and ival != -1 and icnt > 3:
-                            edgearr[x,ival] = -999
-                        cval = -1
-                        icnt = 0
-                        dval = 0.0
-        return edgearr
-        # Match the edges to form groups of traces
-        pedge = 1
-        medge = -1
+    for x in range(sz_x):
+        ival = -1
+        cval = -1
+        icnt = 0
+        dval = 0.0
         for y in range(1,sz_y):
-            for x in range(0,sz_x):
-                if edgearr[x,y] == 0: continue
-                elif edgearr[x,y] == 999:
-                    # Find nearby similar edges
-                    trc = 1 # Boolean, do I keep tracing?
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    nx = x
-                    while trc == 1:
-                        if nx+cmax > sz_x: cmax = sz_x-nx
-                        for i in range(1,cmax):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if y+rmax > sz_y: rmax = sz_y-y
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                if edgearr[nx+i,y+j] == 999:
-                                    if bi == -1:
-                                        bi = y+j
-                                        bv = array[nx+i,y+j]-array[nx,y]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[nx+i,y+j]-array[nx,y]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = y+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[nx+i,bi] = pedge
-                                nx += i
-                                break
-                        if bi == -1: # We've lost the trace!
-                            #pedge += 1
-                            trc = 0
-                elif edgearr[x,y] == -999:
-                    #edgearr[x,y] = medge
-                    trc = 1 # Boolean, do I keep tracing?
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    nx = x
-                    while trc == 1:
-                        if nx+cmax > sz_x: cmax = sz_x-nx
-                        for i in range(1,cmax):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if y+rmax > sz_y: rmax = sz_y-y
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                if edgearr[nx+i,y+j] == -999:
-                                    if bi == -1:
-                                        bi = y+j
-                                        bv = array[nx+i,y+j]-array[nx,y]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[nx+i,y+j]-array[nx,y]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = y+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[nx+i,bi] = pedge
-                                nx += i
-                                break
-                        if bi == -1: # We've lost the trace!
-                            #pedge += 1
-                            trc = 0
-                else: continue
-            # Now trace in the other direction!
-            for x in range(0,sz_x):
-                if edgearr[sz_x-x-1,y] == 0: continue
-                elif edgearr[sz_x-x-1,y] == 999:
-                    # Find nearby similar edges
-                    edgearr[sz_x-x-1,y] = pedge
-                    trc = 1 # Boolean, do I keep tracing?
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    nx = sz_x-x-1
-                    while trc == 1:
-                        if nx-cmax < 0: cmax = 0
-                        for i in range(cmax,sz_x-x-1):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if y+rmax > sz_y: rmax = sz_y-y
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                if edgearr[nx+i,y+j] == 999:
-                                    if bi == -1:
-                                        bi = y+j
-                                        bv = array[nx-i,y+j]-array[nx,y]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[nx-i,y+j]-array[nx,y]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = y+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[nx-i,bi] = pedge
-                                nx -= i
-                                break
-                        if bi == -1: # We've lost the trace!
-                            pedge += 1
-                            trc = 0
-                elif edgearr[sz_x-x-1,y] == -999:
-                    edgearr[sz_x-x-1,y] = medge
-                    trc = 1 # Boolean, do I keep tracing?
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    nx = sz_x-x-1
-                    while trc == 1:
-                        if nx-cmax < 0: cmax = 0
-                        for i in range(cmax,sz_x-x-1):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if y+rmax > sz_y: rmax = sz_y-y
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                if edgearr[nx-i,y+j] == -999:
-                                    if bi == -1:
-                                        bi = y+j
-                                        bv = array[nx-i,y+j]-array[nx,y]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[nx-i,y+j]-array[nx,y]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = y+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[nx-i,bi] = medge
-                                nx -= i
-                                break
-                        if bi == -1: # We've lost the trace!
-                            medge -= 1
-                            trc = 0
-                else: continue
-    #########################
-    # Completed order tracing
-    #########################
-    else: # do this if the dispersion is along a column
-        for y in range(sz_y):
-            ival = -1
-            cval = -1
-            icnt = 0
-            dval = 0.0
-            for x in range(1,sz_x):
-                if array[x,y] == 0.0 or array[x-1,y] == 0.0: continue
-                difval = array[x,y]-array[x-1,y]
-                errval = array[x,y]+array[x-1,y]
-                if errval > 0.0:
-                    errval = csqrt(errval)
-                else:
-                    errval = csqrt(-errval)
-                if difval > 0.0:
-                    if dval < 0.0:
-                        if ival != -1 and icnt > 3: edgearr[ival,y] = -999
-                        ival = -1
-                        cval = -1
-                        icnt = 0
-                        dval = 0.0
-                    if difval/errval > threshold:
-                        if cval == -1:
-                            ival = x
-                            icnt = 1
+            if array[x,y] == 0.0 or array[x,y-1] == 0.0: continue
+            difval = array[x,y]-array[x,y-1]
+            errval = array[x,y]+array[x,y-1]
+            if errval > 0.0:
+                errval = csqrt(errval)
+            else:
+                errval = csqrt(-errval)
+            if difval > 0.0:
+                if dval < 0.0:
+                    if ival != -1 and icnt > 3: edgearr[x,ival] = -999
+                    ival = -1
+                    cval = -1
+                    icnt = 0
+                    dval = 0.0
+                if difval/errval > threshold:
+                    if cval == -1:
+                        ival = y
+                        icnt = 1
+                        dval = difval
+                    elif cval+1 == y:
+                        if difval > dval:
                             dval = difval
-                        elif cval+1 == x:
-                            if difval > dval:
-                                dval = difval
-                                ival = x
-                            icnt += 1
-                        else:
-                            if icnt > 3: edgearr[ival,y] = 999
-                            ival = x
-                            icnt = 1
-                            dval = difval
-                        cval = x
+                            ival = y
+                        icnt += 1
                     else:
-                        if cval != -1 and ival != -1 and icnt > 3:
-                            edgearr[ival,y] = 999
-                        cval = -1
-                        icnt = 0
-                        dval = 0.0
+                        if icnt > 3: edgearr[x,ival] = 999
+                        ival = y
+                        icnt = 1
+                        dval = difval
+                    cval = y
                 else:
-                    if dval > 0.0:
-                        if ival != -1 and icnt > 3: edgearr[ival,y] = 999
-                        ival = -1
-                        cval = -1
-                        icnt = 0
-                        dval = 0.0
-                    if -difval/errval > threshold:
-                        if cval == -1:
-                            ival = x
-                            icnt = 1
+                    if cval != -1 and ival != -1 and icnt > 3:
+                        edgearr[x,ival] = 999
+                    cval = -1
+                    icnt = 0
+                    dval = 0.0
+            else:
+                if dval > 0.0:
+                    if ival != -1 and icnt > 3: edgearr[x,ival] = 999
+                    ival = -1
+                    cval = -1
+                    icnt = 0
+                    dval = 0.0
+                if -difval/errval > threshold:
+                    if cval == -1:
+                        ival = y
+                        icnt = 1
+                        dval = difval
+                    elif cval+1 == y:
+                        if difval < dval:
                             dval = difval
-                        elif cval+1 == x:
-                            if difval < dval:
-                                dval = difval
-                                ival = x
-                            icnt += 1
-                        else:
-                            if icnt > 3: edgearr[ival,y] = -999
-                            ival = x
-                            icnt = 0
-                            dval = difval
-                        cval = x
+                            ival = y
+                        icnt += 1
                     else:
-                        if cval != -1 and ival != -1 and icnt > 3:
-                            edgearr[ival,y] = -999
-                        cval = -1
+                        edgearr[x,ival] = -999
+                        ival = y
                         icnt = 0
-                        dval = 0.0
-        #return edgearr
-        # Match the edges to form groups of traces
-        pedge = 1
-        medge = -1
-        for x in range(1,sz_x):
-            for y in range(0,sz_y):
-                if edgearr[x,y] == 0: continue
-                elif edgearr[x,y] == 999:
-                    # Trace in both directions
-                    # First trace up the chip
-                    # Set some definitions to be used during the UP and DOWN trace
-                    nop = 0 # Number of accepted pixels found in this trace
-                    orderpx = np.zeros((1,2), dtype=ITYPE) # Reset the array of pixel values found for this order
-                    trc = 0 # Once trc reaches some user-specified termination criteria, we've lost the trace.
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    ny = y
-                    while trc < trcign:
-                        # Find nearby similar edges between [0:+srchspe,-srchspa/2:+srchspa/2] and calculate the distance between the current pixel and all these edges.
-                        if ny+cmax > sz_y: cmax = sz_y-ny
-                        for i in range(1,cmax):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if x+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if x+rmax > sz_x: rmax = sz_x-x
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                if edgearr[x+j,ny+i] == 999:
-                                    distt = csqrt( <double>(j**2) + <double>(i**2) )
-                                    tpx = x+j
-                                    tpy = ny+i
-                                    for k in range(trcign):
-                                        if edgenby[k,0] == -999 and edgenby[k,1] == -999:
-                                            edgenby[k,0] = x+j
-                                            edgenby[k,1] = ny+i
-                                        else:
-                                            distp = csqrt( <double>(edgenby[k,0]**2) + <double>(edgenby[k,1]**2) )
-                                            l = k
-                                            while distt <= distp and l<trcign:
-                                                ttx = edgenby[l,0]
-                                                tty = edgenby[l,1]
-                                                edgenby[l,0] = tpx
-                                                edgenby[l,1] = tpy
-                                                tpx = ttx
-                                                tpy = tty
-                                                l+=1
-                        # We have now found the `trcign' closest points to the current order location (sorted by distance in edgenby)
-                        if nop >= swlin:
-                            # Find the closest swlin points to the test point at (edgenby[trc,0],edgenby[trc,1])
-                            closept = get_closest(orderpx,swlin,edgenby[trc,0],edgenby[trc,1])
-                            # Perform linear regression on these points and test if the pixel is deviant
-                            isdev = linreg_test(closept,edgenby[trc,0],edgenby[trc,1],ordthres)
-                            # Test if the pixel is deviant
-                            if isdev==0:
-                                # Add this pixel to the list of successful pixels
-                                orderpx[nop,0] = edgenby[trc,0]
-                                orderpx[nop,1] = edgenby[trc,1]
-                                nop += 1
-                                # Reset trc since we've successfully continued the trace
-                                trc = 0
-                                # Mask out the nearby edges array
-                                for i in range(trcign):
-                                    edgenby[i,0] = -999
-                                    edgenby[i,1] = -999
-                                # Before continuing, confirm that there are no extremely deviant pixels in the `acceptable' pixels
-                                orderpx = clean_pix(orderpx,ordthres)
-                            else:
-                                trc += 1
-                        else:
-                            # Determine the median and MAD of all points
-                            # check that 0 is indeed the dimension we are after
-                            medval, madval = medianmad_dimen(orderpx, 0)
-                            if ordthres: isdev = 1
-                            else: isdev = 0
-                            # Test if the pixel is deviant
-                            if isdev==0:
-                                # Add this pixel to the list of successful pixels
-                                orderpx[nop,0] = edgenby[trc,0]
-                                orderpx[nop,1] = edgenby[trc,1]
-                                nop += 1
-                                # Reset trc since we've successfully continued the trace
-                                trc = 0
-                                # Mask out the nearby edges array
-                                for i in range(trcign):
-                                    edgenby[i,0] = -999
-                                    edgenby[i,1] = -999
-                                # Before continuing, confirm that there are no extremely deviant pixels in the `acceptable' pixels
-                                orderpx = clean_pix(orderpx,ordthres)
-                            else:
-                                trc += 1
-
-                        # Sort these according to distance and get the closest one (call this the test point)
-                        # Suppose we have successfully identified N points as belonging to a given order.
-                        # If N >= 15, then from the test point, find the 15 closest points among the N known points, and call this M points
-                        # Otherwise, just use a vertical line approximation that includes all points ---> call this M points.
-                        # Fit either a linear or vertical line to the M points and check that the test pixel doesn't deviate too far from the trend of M points
-                        # If this test point is deviant, add one to trc, and repeat the process for the next nearest point
-                        # Otherwise, include the test pixel in the confirmed set of pixels and set trc to 0
-                        # Before moving on, check that there are no deviant pixels in the confirmed set.
-                    # Now trace the other direction
-                    # ...
-
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    ny = y
-                    while trc == 1:
-                        if ny+cmax > sz_y: cmax = sz_y-ny
-                        for i in range(1,cmax):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if x+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if x+rmax > sz_x: rmax = sz_x-x
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                #print "+GOING UP!", x, y, i, j, ny, cmax, rmin, rmax, sz_y
-                                if edgearr[x+j,ny+i] == 999:
-                                    if bi == -1:
-                                        bi = x+j
-                                        bv = array[x+j,ny+i]-array[x,ny]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[x+j,ny+i]-array[x,ny]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = x+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[bi,ny+i] = pedge
-                                ny += i
-                                break
-                        if bi == -1 or ny+1 >= sz_y: # We've lost the trace or reached the end of the chip!
-                            #pedge += 1
-                            trc = 0
-                elif edgearr[x,y] == -999:
-                    #edgearr[x,y] = medge
-                    trc = 1 # Boolean, do I keep tracing?
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    ny = y
-                    while trc == 1:
-                        if ny+cmax > sz_y: cmax = sz_y-ny
-                        for i in range(1,cmax):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if x+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if x+rmax > sz_x: rmax = sz_x-x
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                #print "-GOING UP!", x, y, i, j, ny, cmax, rmin, rmax
-                                if edgearr[x+j,ny+i] == -999:
-                                    if bi == -1:
-                                        bi = x+j
-                                        bv = array[x+j,ny+i]-array[x,ny]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[x+j,ny+i]-array[x,ny]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = x+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[bi,ny+i] = medge
-                                ny += i
-                                break
-                        if bi == -1 or ny+1 >= sz_y: # We've lost the trace!
-                            #medge -= 1
-                            trc = 0
-                else: continue
-                # Now apply the order numbers from orderpx to edgearr
-
-                # Complete!
-
-
-
-
-            #### NOOOO!!!! Don't trace the other direction, it's already done!
-            # Now trace in the other direction!
-            for y in range(0,sz_y):
-                if edgearr[x,sz_y-y-1] == 0: continue
-                elif edgearr[x,sz_y-y-1] == 999:
-                    # Find nearby similar edges
-                    edgearr[x,sz_y-y-1] = pedge
-                    trc = 1 # Boolean, do I keep tracing?
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    ny = sz_y-y-1
-                    while trc == 1:
-                        if ny+1 < cmax: cmax = ny+1
-                        for i in range(1,cmax):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if x+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if x+rmax > sz_x: rmax = sz_x-x
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                #print "+GOING DOWN!", x, y, i, j, ny, cmax, rmin, rmax
-                                if edgearr[x+j,ny-i] == 999:
-                                    if bi == -1:
-                                        bi = x+j
-                                        bv = array[x+j,ny-i]-array[x,ny]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[x+j,ny-i]-array[x,ny]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = x+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[bi,ny-i] = pedge
-                                ny -= i
-                                break
-                        if bi == -1 or ny < 1: # We've lost the trace or reached the end of the chip!
-                            pedge += 1
-                            trc = 0
-                elif edgearr[x,sz_y-y-1] == -999:
-                    edgearr[x,sz_y-y-1] = medge
-                    trc = 1 # Boolean, do I keep tracing?
-                    cmax = 1+srchspe # Go srchspe pixels beyond the current one
-                    ny = sz_y-y-1
-                    while trc == 1:
-                        if ny+1 < cmax: cmax = ny+1
-                        for i in range(1,cmax):
-                            rmin = -(srchspa-1)/2
-                            rmax = 1-rmin
-                            if x+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
-                            if x+rmax > sz_x: rmax = sz_x-x
-                            bi = -1
-                            bv = 0.0
-                            for j in range(rmin,rmax):
-                                #print "-GOING DOWN!", x, y, i, j, ny, cmax, rmin, rmax
-                                if edgearr[x+j,ny-i] == -999:
-                                    if bi == -1:
-                                        bi = x+j
-                                        bv = array[x+j,ny-i]-array[x,ny]
-                                        if bv < 0.0: bv = -bv
-                                    else:
-                                        tval = array[x+j,ny-i]-array[x,ny]
-                                        if tval < 0.0: tval = -tval
-                                        if tval < bv:
-                                            bi = x+j
-                                            bv = tval
-                            if bi != -1: # We're continuing the trace
-                                edgearr[bi,ny-i] = medge
-                                ny -= i
-                                break
-                        if bi == -1 or ny < 1: # We've lost the trace or reached the end of the chip!
-                            medge -= 1
-                            trc = 0
-                else: continue
+                        dval = difval
+                    cval = y
+                else:
+                    if cval != -1 and ival != -1 and icnt > 3:
+                        edgearr[x,ival] = -999
+                    cval = -1
+                    icnt = 0
+                    dval = 0.0
+    return edgearr
+    # Match the edges to form groups of traces
+    pedge = 1
+    medge = -1
+    for y in range(1,sz_y):
+        for x in range(0,sz_x):
+            if edgearr[x,y] == 0: continue
+            elif edgearr[x,y] == 999:
+                # Find nearby similar edges
+                trc = 1 # Boolean, do I keep tracing?
+                cmax = 1+srchspe # Go srchspe pixels beyond the current one
+                nx = x
+                while trc == 1:
+                    if nx+cmax > sz_x: cmax = sz_x-nx
+                    for i in range(1,cmax):
+                        rmin = -(srchspa-1)/2
+                        rmax = 1-rmin
+                        if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
+                        if y+rmax > sz_y: rmax = sz_y-y
+                        bi = -1
+                        bv = 0.0
+                        for j in range(rmin,rmax):
+                            if edgearr[nx+i,y+j] == 999:
+                                if bi == -1:
+                                    bi = y+j
+                                    bv = array[nx+i,y+j]-array[nx,y]
+                                    if bv < 0.0: bv = -bv
+                                else:
+                                    tval = array[nx+i,y+j]-array[nx,y]
+                                    if tval < 0.0: tval = -tval
+                                    if tval < bv:
+                                        bi = y+j
+                                        bv = tval
+                        if bi != -1: # We're continuing the trace
+                            edgearr[nx+i,bi] = pedge
+                            nx += i
+                            break
+                    if bi == -1: # We've lost the trace!
+                        #pedge += 1
+                        trc = 0
+            elif edgearr[x,y] == -999:
+                #edgearr[x,y] = medge
+                trc = 1 # Boolean, do I keep tracing?
+                cmax = 1+srchspe # Go srchspe pixels beyond the current one
+                nx = x
+                while trc == 1:
+                    if nx+cmax > sz_x: cmax = sz_x-nx
+                    for i in range(1,cmax):
+                        rmin = -(srchspa-1)/2
+                        rmax = 1-rmin
+                        if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
+                        if y+rmax > sz_y: rmax = sz_y-y
+                        bi = -1
+                        bv = 0.0
+                        for j in range(rmin,rmax):
+                            if edgearr[nx+i,y+j] == -999:
+                                if bi == -1:
+                                    bi = y+j
+                                    bv = array[nx+i,y+j]-array[nx,y]
+                                    if bv < 0.0: bv = -bv
+                                else:
+                                    tval = array[nx+i,y+j]-array[nx,y]
+                                    if tval < 0.0: tval = -tval
+                                    if tval < bv:
+                                        bi = y+j
+                                        bv = tval
+                        if bi != -1: # We're continuing the trace
+                            edgearr[nx+i,bi] = pedge
+                            nx += i
+                            break
+                    if bi == -1: # We've lost the trace!
+                        #pedge += 1
+                        trc = 0
+            else: continue
+        # Now trace in the other direction!
+        for x in range(0,sz_x):
+            if edgearr[sz_x-x-1,y] == 0: continue
+            elif edgearr[sz_x-x-1,y] == 999:
+                # Find nearby similar edges
+                edgearr[sz_x-x-1,y] = pedge
+                trc = 1 # Boolean, do I keep tracing?
+                cmax = 1+srchspe # Go srchspe pixels beyond the current one
+                nx = sz_x-x-1
+                while trc == 1:
+                    if nx-cmax < 0: cmax = 0
+                    for i in range(cmax,sz_x-x-1):
+                        rmin = -(srchspa-1)/2
+                        rmax = 1-rmin
+                        if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
+                        if y+rmax > sz_y: rmax = sz_y-y
+                        bi = -1
+                        bv = 0.0
+                        for j in range(rmin,rmax):
+                            if edgearr[nx+i,y+j] == 999:
+                                if bi == -1:
+                                    bi = y+j
+                                    bv = array[nx-i,y+j]-array[nx,y]
+                                    if bv < 0.0: bv = -bv
+                                else:
+                                    tval = array[nx-i,y+j]-array[nx,y]
+                                    if tval < 0.0: tval = -tval
+                                    if tval < bv:
+                                        bi = y+j
+                                        bv = tval
+                        if bi != -1: # We're continuing the trace
+                            edgearr[nx-i,bi] = pedge
+                            nx -= i
+                            break
+                    if bi == -1: # We've lost the trace!
+                        pedge += 1
+                        trc = 0
+            elif edgearr[sz_x-x-1,y] == -999:
+                edgearr[sz_x-x-1,y] = medge
+                trc = 1 # Boolean, do I keep tracing?
+                cmax = 1+srchspe # Go srchspe pixels beyond the current one
+                nx = sz_x-x-1
+                while trc == 1:
+                    if nx-cmax < 0: cmax = 0
+                    for i in range(cmax,sz_x-x-1):
+                        rmin = -(srchspa-1)/2
+                        rmax = 1-rmin
+                        if y+rmin < 1: rmin = 1 # 1 because there's nothing in the zeroth column
+                        if y+rmax > sz_y: rmax = sz_y-y
+                        bi = -1
+                        bv = 0.0
+                        for j in range(rmin,rmax):
+                            if edgearr[nx-i,y+j] == -999:
+                                if bi == -1:
+                                    bi = y+j
+                                    bv = array[nx-i,y+j]-array[nx,y]
+                                    if bv < 0.0: bv = -bv
+                                else:
+                                    tval = array[nx-i,y+j]-array[nx,y]
+                                    if tval < 0.0: tval = -tval
+                                    if tval < bv:
+                                        bi = y+j
+                                        bv = tval
+                        if bi != -1: # We're continuing the trace
+                            edgearr[nx-i,bi] = medge
+                            nx -= i
+                            break
+                    if bi == -1: # We've lost the trace!
+                        medge -= 1
+                        trc = 0
+            else: continue
     return edgearr
 
 
@@ -1729,7 +1391,7 @@ def ignore_orders(np.ndarray[ITYPE_t, ndim=2] edgdet not None,
 
 @cython.boundscheck(False)
 def label_orders_two(np.ndarray[ITYPE_t, ndim=2] edgdet not None,
-                int dispdir, int lcnt, int rcnt):
+                int lcnt, int rcnt):
     cdef int sz_x, sz_y, cnt
     cdef int x, y, c, j
     cdef double lvcnt, rvcnt, lncnt, rncnt
@@ -1741,8 +1403,8 @@ def label_orders_two(np.ndarray[ITYPE_t, ndim=2] edgdet not None,
     if lcnt > rcnt: cnt = lcnt
     else: cnt = rcnt
 
-    sz_x = edgdet.shape[dispdir]
-    sz_y = edgdet.shape[1-dispdir]
+    sz_x = edgdet.shape[0]
+    sz_y = edgdet.shape[1]
 
     cdef np.ndarray[DTYPE_t, ndim=2] larr = np.zeros((2,lcnt), dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=2] rarr = np.zeros((2,rcnt), dtype=DTYPE)
@@ -1754,20 +1416,12 @@ def label_orders_two(np.ndarray[ITYPE_t, ndim=2] edgdet not None,
         rncnt = 0.0
         for x in range(sz_x):
             for y in range(sz_y):
-                if dispdir == 0:
-                    if edgdet[x,y] == c:
-                        rvcnt += <double>(y)
-                        rncnt += 1.0
-                    elif edgdet[x,y] == -c:
-                        lvcnt += <double>(y)
-                        lncnt += 1.0
-                else:
-                    if edgdet[y,x] == c:
-                        rvcnt += <double>(y)
-                        rncnt += 1.0
-                    elif edgdet[y,x] == -c:
-                        lvcnt += <double>(y)
-                        lncnt += 1.0
+                if edgdet[x,y] == c:
+                    rvcnt += <double>(y)
+                    rncnt += 1.0
+                elif edgdet[x,y] == -c:
+                    lvcnt += <double>(y)
+                    lncnt += 1.0
         if lncnt != 0.0:
             larr[0,c-1000] = <double>(c)
             larr[1,c-1000] = lvcnt/lncnt
@@ -1799,28 +1453,16 @@ def label_orders_two(np.ndarray[ITYPE_t, ndim=2] edgdet not None,
     for c in range(1000,1000+cnt):
         for x in range(sz_x):
             for y in range(sz_y):
-                if dispdir == 0:
-                    if edgdet[x,y] == c:
-                        for j in range(rcnt):
-                            if rarr[0,j] == <double>(c):
-                                edgdet[x,y] = j+1
-                                break
-                    elif edgdet[x,y] == -c:
-                        for j in range(lcnt):
-                            if larr[0,j] == <double>(c):
-                                edgdet[x,y] = -j-1
-                                break
-                else:
-                    if edgdet[y,x] == c:
-                        for j in range(rcnt):
-                            if rarr[0,j] == <double>(c):
-                                edgdet[y,x] = j+1
-                                break
-                    elif edgdet[y,x] == -c:
-                        for j in range(lcnt):
-                            if larr[0,j] == <double>(c):
-                                edgdet[y,x] = -j-1
-                                break
+                if edgdet[x,y] == c:
+                    for j in range(rcnt):
+                        if rarr[0,j] == <double>(c):
+                            edgdet[x,y] = j+1
+                            break
+                elif edgdet[x,y] == -c:
+                    for j in range(lcnt):
+                        if larr[0,j] == <double>(c):
+                            edgdet[x,y] = -j-1
+                            break
     return
 
 
@@ -2116,21 +1758,17 @@ def medianmaskmin(np.ndarray[DTYPE_t, ndim=1] array not None, double mask):
 @cython.boundscheck(False)
 def median_ed(np.ndarray[DTYPE_t, ndim=2] array not None,
             np.ndarray[DTYPE_t, ndim=2] medarr not None,
-            int dispdir, int x, int ms):
+            int x, int ms):
     cdef int sz_y
     cdef int y, i, j
     cdef double temp
 
-    sz_y = array.shape[1-dispdir]
+    sz_y = array.shape[1]
 
     # Extract the relevant pieces of the array
     for y in range(sz_y):
-        if dispdir == 0:
-            for i in range(2*ms+1):
-                medarr[y,i] = array[x+i-ms,y]
-        else:
-            for i in range(2*ms+1):
-                medarr[y,i] = array[y,x+i-ms]
+        for i in range(2*ms+1):
+            medarr[y,i] = array[x+i-ms,y]
 
     # Sort the array
     for y in range(sz_y-1):
@@ -2241,13 +1879,12 @@ def medianmad_dimen(np.ndarray[DTYPE_t, ndim=1] array not None, int di):
 @cython.boundscheck(False)
 def minbetween(np.ndarray[DTYPE_t, ndim=2] mstrace not None,
                 np.ndarray[ITYPE_t, ndim=1] loord not None,
-                np.ndarray[ITYPE_t, ndim=1] hiord not None,
-                int dispdir):
+                np.ndarray[ITYPE_t, ndim=1] hiord not None):
     cdef int sz_x, sz_y
     cdef int x, y, ymin, ymax
 
-    sz_x = mstrace.shape[dispdir]
-    sz_y = mstrace.shape[1-dispdir]
+    sz_x = mstrace.shape[0]
+    sz_y = mstrace.shape[1]
 
     cdef np.ndarray[DTYPE_t, ndim=1] minarr = np.zeros(sz_x, dtype=DTYPE)
 
@@ -2257,16 +1894,10 @@ def minbetween(np.ndarray[DTYPE_t, ndim=2] mstrace not None,
         if ymin < 0: ymin = 0
         elif ymax > sz_y: ymax = sz_y
         for y in range(ymin,ymax):
-            if dispdir == 0:
-                if mstrace[x,y] < minarr[x] and mstrace[x,y] > 0.0:
-                    minarr[x] = mstrace[x,y]
-                elif minarr[x] == 0.0:
-                    minarr[x] = mstrace[x,y]
-            else:
-                if mstrace[y,x] < minarr[x] and mstrace[y,x] > 0.0:
-                    minarr[x] = mstrace[y,x]
-                elif minarr[x] == 0.0:
-                    minarr[x] = mstrace[y,x]
+            if mstrace[x,y] < minarr[x] and mstrace[x,y] > 0.0:
+                minarr[x] = mstrace[x,y]
+            elif minarr[x] == 0.0:
+                minarr[x] = mstrace[x,y]
     return minarr
 
 
@@ -2621,7 +2252,7 @@ def trace_tilts(np.ndarray[DTYPE_t, ndim=2] msarc not None,
                 np.ndarray[ITYPE_t, ndim=2] ordcen not None,
                 np.ndarray[ITYPE_t, ndim=2] ordsiz not None,
                 np.ndarray[ITYPE_t, ndim=2] arccen not None,
-                int dispdir, int maxnum):
+                int maxnum):
     """
     pseudo-maximum likelihood estimate for the trace of the arc lines.
     """
@@ -2635,8 +2266,8 @@ def trace_tilts(np.ndarray[DTYPE_t, ndim=2] msarc not None,
     sz_l = arccen.shape[0]
     sz_o = arccen.shape[1]
 
-    cdef int sz_ax = msarc.shape[1-dispdir]
-    cdef int sz_ay = msarc.shape[dispdir]
+    cdef int sz_ax = msarc.shape[1]
+    cdef int sz_ay = msarc.shape[0]
 
     cdef np.ndarray[DTYPE_t, ndim=2] derv = np.zeros((sz_l,sz_o), dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=2] cent = np.zeros((sz_l,sz_o), dtype=DTYPE)
@@ -2663,24 +2294,14 @@ def trace_tilts(np.ndarray[DTYPE_t, ndim=2] msarc not None,
             if ymax+arccen[l,o] > sz_ay: ymax = sz_ay-arccen[l,o]
             for x in range(xmin,xmax):
                 for y in range(ymin,ymax):
-                    if dispdir == 0:
-                        if msarc[y,x] < back[2*maxnum-1] or back[2*maxnum-1] == -1.0:
-                            for b in range(0,2*maxnum):
-                                if back[b] == -1.0: back[b] = msarc[y,x]
-                                elif back[b] > msarc[y,x]: # Rearrange
-                                    for bb in range(b+1,2*maxnum):
-                                        back[2*maxnum+b-bb] = back[2*maxnum+b-bb-1]
-                                    back[b] = msarc[y,x]
-                                    break
-                    else:
-                        if msarc[x,y] < back[2*maxnum-1] or back[2*maxnum-1] == -1.0:
-                            for b in range(0,2*maxnum):
-                                if back[b] == -1.0: back[b] = msarc[x,y]
-                                elif back[b] > msarc[x,y]: # Rearrange
-                                    for bb in range(b+1,2*maxnum):
-                                        back[2*maxnum+b-bb] = back[2*maxnum+b-bb-1]
-                                    back[b] = msarc[x,y]
-                                    break
+                    if msarc[y,x] < back[2*maxnum-1] or back[2*maxnum-1] == -1.0:
+                        for b in range(0,2*maxnum):
+                            if back[b] == -1.0: back[b] = msarc[y,x]
+                            elif back[b] > msarc[y,x]: # Rearrange
+                                for bb in range(b+1,2*maxnum):
+                                    back[2*maxnum+b-bb] = back[2*maxnum+b-bb-1]
+                                back[b] = msarc[y,x]
+                                break
             bval = 0.0
             for b in range(0,2*maxnum):
                 bval += back[b]
@@ -2694,12 +2315,8 @@ def trace_tilts(np.ndarray[DTYPE_t, ndim=2] msarc not None,
             if ymin < 0: ymin = 0
             if ymax > sz_ay: ymax = sz_ay
             for y in range(ymin,ymax):
-                if dispdir == 0:
-                    mval += <double>(y)*(msarc[y,ordcen[l,o]]-bval)
-                    wght += (msarc[y,ordcen[l,o]]-bval)
-                else:
-                    mval += <double>(y)*(msarc[ordcen[l,o],y]-bval)
-                    wght += (msarc[ordcen[l,o],y]-bval)
+                mval += <double>(y)*(msarc[y,ordcen[l,o]]-bval)
+                wght += (msarc[y,ordcen[l,o]]-bval)
             xfit[0] = 0.0
             yfit[0] = mval/wght
             nfit += 1
@@ -2718,12 +2335,8 @@ def trace_tilts(np.ndarray[DTYPE_t, ndim=2] msarc not None,
                 if ymin < 0: ymin = 0
                 if ymax > sz_ay: ymax = sz_ay
                 for y in range(ymin,ymax):
-                    if dispdir == 0:
-                        mval += <double>(y)*(msarc[y,ordcen[l,o]+x]-bval)
-                        wght += (msarc[y,ordcen[l,o]+x]-bval)
-                    else:
-                        mval += <double>(y)*(msarc[ordcen[l,o]+x,y]-bval)
-                        wght += (msarc[ordcen[l,o]+x,y]-bval)
+                    mval += <double>(y)*(msarc[y,ordcen[l,o]+x]-bval)
+                    wght += (msarc[y,ordcen[l,o]+x]-bval)
                 xfit[nfit] = <double>(x)
                 yfit[nfit] = mval/wght
                 nfit += 1
@@ -2743,12 +2356,8 @@ def trace_tilts(np.ndarray[DTYPE_t, ndim=2] msarc not None,
                 if ymin < 0: ymin = 0
                 if ymax > sz_ay: ymax = sz_ay
                 for y in range(ymin,ymax):
-                    if dispdir == 0:
-                        mval += <double>(y)*(msarc[y,ordcen[l,o]-x]-bval)
-                        wght += (msarc[y,ordcen[l,o]-x]-bval)
-                    else:
-                        mval += <double>(y)*(msarc[ordcen[l,o]-x,y]-bval)
-                        wght += (msarc[ordcen[l,o]-x,y]-bval)
+                    mval += <double>(y)*(msarc[y,ordcen[l,o]-x]-bval)
+                    wght += (msarc[y,ordcen[l,o]-x]-bval)
                 xfit[nfit] = <double>(-x)
                 yfit[nfit] = mval/wght
                 nfit += 1

--- a/pypit/arsciexp.py
+++ b/pypit/arsciexp.py
@@ -36,8 +36,6 @@ class ScienceExposure:
 
     def __init__(self, snum, fitsdict, do_qa=True):
 
-        self._dispaxis = 0  # This should always be zero, and this line can be deleted once all instances throughout code are removed
-
         # Set indices used for frame combination
         self._idx_sci = settings.spect['science']['index'][snum]
         self._idx_arcs = settings.spect['arc']['index'][snum]
@@ -205,9 +203,9 @@ class ScienceExposure:
           Index of the detector
         """
         if settings.argflag['reduce']['pixel']['locations'] is None:
-            self.SetFrame(self._pixlocn, artrace.gen_pixloc(self._dispaxis, self._mstrace[det-1], det, gen=True), det)
+            self.SetFrame(self._pixlocn, artrace.gen_pixloc(self._mstrace[det-1], det, gen=True), det)
         elif settings.argflag['reduce']['pixel']['locations'] in ["mstrace"]:
-            self.SetFrame(self._pixlocn, artrace.gen_pixloc(self._dispaxis, self._mstrace[det-1], det, gen=False), det)
+            self.SetFrame(self._pixlocn, artrace.gen_pixloc(self._mstrace[det-1], det, gen=False), det)
         else:
             mname = settings.argflag['run']['directory']['master']+'/'+settings.argflag['reduce']['pixel']['locations']
             self.SetFrame(self._pixlocn, arload.load_master(mname, frametype=None), det)

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -491,10 +491,10 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     if False:
         # Use this for debugging
         binbpx = np.zeros(mstrace.shape, dtype=np.int)
-        xs = np.arange(mstrace.shape[slf._dispaxis] * 1.0) * settings.spect[dnum]['xgap']
-        xt = 0.5 + np.arange(mstrace.shape[slf._dispaxis] * 1.0) + xs
-        ys = np.arange(mstrace.shape[1 - slf._dispaxis]) * settings.spect[dnum]['ygap'] * settings.spect[dnum]['ysize']
-        yt = settings.spect[dnum]['ysize'] * (0.5 + np.arange(mstrace.shape[1 - slf._dispaxis] * 1.0)) + ys
+        xs = np.arange(mstrace.shape[0] * 1.0) * settings.spect[dnum]['xgap']
+        xt = 0.5 + np.arange(mstrace.shape[0] * 1.0) + xs
+        ys = np.arange(mstrace.shape[1]) * settings.spect[dnum]['ygap'] * settings.spect[dnum]['ysize']
+        yt = settings.spect[dnum]['ysize'] * (0.5 + np.arange(mstrace.shape[1] * 1.0)) + ys
         xloc, yloc = np.meshgrid(xt, yt)
         plxbin, plybin = xloc.T, yloc.T
     #    binby = 5
@@ -738,7 +738,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
         lmin, lmax = -np.max(edgearr[ww]), -np.min(edgearr[ww])  # min/max are switched because of the negative signs
         ww = np.where(edgearr > 0)
         rmin, rmax = np.min(edgearr[ww]), np.max(edgearr[ww])  # min/max are switched because of the negative signs
-        #msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[slf._dispaxis]*binby)))
+        #msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0]*binby)))
         msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0])))
         fracpix = int(settings.argflag['trace']['slits']['fracignore']*edgearr.shape[0])
         lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
@@ -796,9 +796,9 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
                                                         settings.argflag['trace']['slits']['polyorder'],
                                                         function=settings.argflag['trace']['slits']['function'],
                                                         minv=minvf, maxv=maxvf)
-#		xv=np.linspace(0,edgearr.shape[slf._dispaxis-0])
+#		xv=np.linspace(0,edgearr.shape[0])
 #		yv=np.polyval(coeffl[i-lmin,:],xv)
-#		plt.plot(w[slf._dispaxis-0],w[1-slf._dispaxis],'ro')
+#		plt.plot(w[0],w[1],'ro')
 #		plt.plot(xv,yv,'r-')
 #		plt.show()
 #		plt.clf()
@@ -867,7 +867,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
 
     """
     lvp = (arutils.func_val(lcoeff[:,lval+1-lmin],xv,settings.argflag['trace']['slits']['function'],min=minvf,max=maxvf)+0.5).astype(np.int)
-    edgbtwn = arcytrace.find_between(edgearr,lv,lvp,slf._dispaxis,1)
+    edgbtwn = arcytrace.find_between(edgearr,lv,lvp,1)
     print lval, edgbtwn
     # edgbtwn is a 3 element array that determines what is between two adjacent left edges
     # edgbtwn[0] is the next right order along, from left order lval
@@ -929,12 +929,8 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
 #			ymga = ymga.flatten().astype(np.int)
 #			xmgb = xmgb.flatten().astype(np.int)
 #			ymgb = ymgb.flatten().astype(np.int)
-#			if slf._dispaxis == 0:
-#				meda = np.median(binarr[xmga,ymga])
-#				medb = np.median(binarr[xmgb,ymgb])
-#			else:
-#				meda = np.median(binarr[ymga,xmga])
-#				medb = np.median(binarr[ymgb,xmgb])
+#			meda = np.median(binarr[xmga,ymga])
+#			medb = np.median(binarr[xmgb,ymgb])
 #			if meda > medb:
 #				rsub = rmin+i-1-500
 #			else:
@@ -1044,7 +1040,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
         # NOTE::  MIGHT NEED TO APPLY THE BAD PIXEL MASK HERE TO BINARR
         msgs.work("Should the bad pixel mask be applied to the frame here?")
         refine_cent, outpar = refine_traces(binarr, outpar, extrap_cent, extrap_diff,
-                                            [gord[0]-orders[0], orders[-1]-gord[-1]], orders, slf._dispaxis,
+                                            [gord[0]-orders[0], orders[-1]-gord[-1]], orders,
                                             ofit[0], slf._pixlocn[det-1],
                                             function=settings.argflag['trace']['slits']['function'])
         # Generate the left and right edges
@@ -1158,7 +1154,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     return lcenint, rcenint, extrapord
 
 
-def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders, dispaxis,
+def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
                   fitord, locations, function='polynomial'):
     """
     Parameters
@@ -1169,7 +1165,6 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders, disp
     extrap_diff
     extord
     orders
-    dispaxis
     fitord
     locations
     function
@@ -1192,14 +1187,14 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders, disp
         loord = hiord
         hiord = nxord
         nxord = phys_to_pix(extrap_cent[:,-i], locations, 1)
-        minarrL = arcytrace.minbetween(binarr, loord, hiord, dispaxis) # Minimum counts between loord and hiord
-        minarrR = arcytrace.minbetween(binarr, hiord, nxord, dispaxis)
+        minarrL = arcytrace.minbetween(binarr, loord, hiord) # Minimum counts between loord and hiord
+        minarrR = arcytrace.minbetween(binarr, hiord, nxord)
         minarr = 0.5*(minarrL+minarrR)
         srchz = np.abs(extfit[:,-i]-extfit[:,-i-1])/3.0
         lopos = phys_to_pix(extfit[:,-i]-srchz, locations, 1) # The pixel indices for the bottom of the search window
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,-i])))
         diffarr = np.round(extrap_diff[:,-i]).astype(np.int)
-        shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch, dispaxis)
+        shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
         relshift = np.mean(shift+extrap_diff[:,-i]/2-srchz)
         if shift == -1:
             msgs.info("  Refining order {0:d}: NO relative shift applied".format(int(orders[-i])))
@@ -1221,12 +1216,12 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders, disp
     while i > 0:
         hiord = loord
         loord = phys_to_pix(extfit[:,i], locations, 1)
-        minarr = arcytrace.minbetween(binarr,loord, hiord, dispaxis)
+        minarr = arcytrace.minbetween(binarr,loord, hiord)
         srchz = np.abs(extfit[:,i]-extfit[:,i-1])/3.0
         lopos = phys_to_pix(extfit[:,i-1]-srchz, locations, 1)
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,i-1])))
         diffarr = np.round(extrap_diff[:,i-1]).astype(np.int)
-        shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch, dispaxis)
+        shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
         relshift = np.mean(shift+extrap_diff[:,i-1]/2-srchz)
         if shift == -1:
             msgs.info("  Refining order {0:d}: NO relative shift applied".format(int(orders[i-1])))
@@ -1857,8 +1852,8 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
     derv = -derv
     if settings.argflag['trace']['slits']['tilts']['method'] == 'perp':
         tilts = derv
-#	plt.plot(np.arange(msarc.shape[slf._dispaxis]),slf._lordloc[:,10],'g-')
-#	plt.plot(np.arange(msarc.shape[slf._dispaxis]),slf._rordloc[:,10],'b-')
+#	plt.plot(np.arange(msarc.shape[0]),slf._lordloc[:,10],'g-')
+#	plt.plot(np.arange(msarc.shape[0]),slf._rordloc[:,10],'b-')
 #	showtilts=np.array([10,50,800,1000,2000,3000,3300,3600])
 #	for j in range(showtilts.size):
 #		xplt = np.arange(-5,5)+showtilts[j]
@@ -1872,12 +1867,8 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
     tordcen = None
     maskorder = np.zeros(ocen.shape[1],dtype=np.int)
     for i in range(ocen.shape[1]):
-        if slf._dispaxis == 0:
-            wl = np.size(np.where(ocen[:,i] <= slf._pixlocn[det-1][0,0,1])[0])
-            wh = np.size(np.where(ocen[:,i] >= slf._pixlocn[det-1][0,-1,1])[0])
-        else:
-            wl = np.size(np.where(ocen[:,i] <= slf._pixlocn[det-1][0,0,1])[0])
-            wh = np.size(np.where(ocen[:,i] >= slf._pixlocn[det-1][-1,0,1])[0])
+        wl = np.size(np.where(ocen[:,i] <= slf._pixlocn[det-1][0,0,1])[0])
+        wh = np.size(np.where(ocen[:,i] >= slf._pixlocn[det-1][0,-1,1])[0])
         if wl==0 and wh==0: # The center of the order is always on the chip
             if tordcen is None:
                 tordcen = np.zeros((ocen.shape[0],1),dtype=np.int)
@@ -1911,37 +1902,20 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
     om2[w] += 1
     w = np.where(om2==-2)
     om2[w] += 2
-    if slf._dispaxis == 0:
-        w = np.where(op1>=msarc.shape[1])
-        op1[w] -= 1
-        w = np.where(op2==msarc.shape[1])
-        op2[w] -= 1
-        w = np.where(op2==msarc.shape[1]+1)
-        op2[w] -= 2
-        arccen = (msarc[temparr,ordcen]+msarc[temparr,op1]+msarc[temparr,op2]+msarc[temparr,om1]+msarc[temparr,om2])/5.0
-#		arccel = (msarc[temparr,ordcen-2])#+msarc[temparr,ordcen+1]+msarc[temparr,ordcen-1])/3.0
-#		arccer = (msarc[temparr,ordcen+2])#+msarc[temparr,ordcen+1]+msarc[temparr,ordcen-1])/3.0
-    else:
-        w = np.where(op1>=msarc.shape[0])
-        op1[w] -= 1
-        w = np.where(op2==msarc.shape[0])
-        op2[w] -= 1
-        w = np.where(op2==msarc.shape[0]+1)
-        op2[w] -= 2
-        arccen = (msarc[ordcen,temparr]+msarc[op1,temparr]+msarc[op2,temparr]+msarc[om1,temparr]+msarc[om2,temparr])/5.0
+    w = np.where(op1>=msarc.shape[1])
+    op1[w] -= 1
+    w = np.where(op2==msarc.shape[1])
+    op2[w] -= 1
+    w = np.where(op2==msarc.shape[1]+1)
+    op2[w] -= 2
+    arccen = (msarc[temparr,ordcen]+msarc[temparr,op1]+msarc[temparr,op2]+msarc[temparr,om1]+msarc[temparr,om2])/5.0
+#	arccel = (msarc[temparr,ordcen-2])#+msarc[temparr,ordcen+1]+msarc[temparr,ordcen-1])/3.0
+#	arccer = (msarc[temparr,ordcen+2])#+msarc[temparr,ordcen+1]+msarc[temparr,ordcen-1])/3.0
     del temparr
-#		arccel = (msarc[ordcen-2,temparr])#+msarc[ordcen+1,temparr]+msarc[ordcen-1,temparr])/3.0
-#		arccer = (msarc[ordcen+2,temparr])#+msarc[ordcen+1,temparr]+msarc[ordcen-1,temparr])/3.0
-#	for i in range(arccen.shape[1]):
-#		plt.clf()
-#		plt.plot(pixcen,arccen[:,i],'g-')
-#		plt.plot(pixcen,arccer[:,i],'r-')
-#		plt.plot(pixcen,arccel[:,i],'b-')
-#		plt.show()
     msgs.info("Generating a mask of arc line saturation streaks")
     satmask = arcyarc.saturation_mask(msarc, settings.spect['det']['saturation']*settings.spect['det']['nonlinear'])
     ordwid = 0.5*np.abs(slf._lordloc-slf._rordloc)
-    satsnd = arcyarc.order_saturation(satmask,ordcen,(ordwid+0.5).astype(np.int),slf._dispaxis)
+    satsnd = arcyarc.order_saturation(satmask,ordcen,(ordwid+0.5).astype(np.int))
 #	arutils.ds9plot((1.0-satmask)*msarc)
 #	plt.plot(pixcen,arccen[:,10],'k-',drawstyle='steps')
 #	plt.show()
@@ -2027,112 +2001,58 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
             pixt = arcdet[np.where(arcdet[:,nm]!=-1)[0],nm]
             for j in range(pixt.size): # For each detection in this order
                 sz = int(np.floor(np.abs(slf._rordloc[pixt[j],i]-slf._lordloc[pixt[j],i])/2.0))-1
-                if slf._dispaxis == 0:
-                    xtfit = np.arange(-sz,sz+1,1.0) # pixel along the arc line
-                    ytfit = np.zeros(2*sz+1) # Fitted centroid
-                    etfit = np.zeros(2*sz+1) # Fitted centroid error
-                    mtfit = np.zeros(2*sz+1) # Mask of bad fits
-                    # Fit up
-                    pcen = pixt[j]
-                    if (pcen < 3) or (pcen > msarc.shape[0]-4): continue
-                    offchip = False
-                    for k in range(0,sz+1):
-                        if (pcen < 3) or (pcen > msarc.shape[0]-4):
-                            offchip == True
-                            break
-                        if ordcen[pcen,nm]+k >= msarc.shape[1]:
-                            mtfit[k+sz] = 1.0
-                            offchip = True
-                            break
-                        xfit = np.arange(pcen-3, pcen+3+1, 1.0)  # 2x4 + 1 = 9 pixels total along the spectral dimension
-                        yfit = msarc[pcen-3:pcen+3+1,ordcen[pcen,nm]+k]
-                        if np.size(yfit) == 0:
-                            mtfit[k+sz] = 1.0
-                            offchip = True
-                            break
-                        #params, perror, fail = arfitbase.fit_gauss(xfit,yfit)
-                        params, fail = arutils.gauss_fit(xfit,yfit,pcen)
-                        ytfit[k+sz] = params[1]
-                        etfit[k+sz] = 0.02
-                        if fail: mtfit[k+sz] = 1.0
-                        else: pcen = int(0.5+params[1])
-                    if offchip: continue
-                    # Fit down
-                    pcen = int(0.5+ytfit[sz]) # Start with the best-fitting centroid at arccen
-                    for k in range(1,sz+1):
-                        if (pcen < 3) or (pcen > msarc.shape[0]-4):
-                            offchip == True
-                            break
-                        if ordcen[pcen,nm]-k < 0:
-                            mtfit[sz-k] = 1.0
-                            offchip = True
-                            break
-                        xfit = np.arange(pcen-3, pcen+3+1, 1.0)
-                        yfit = msarc[pcen-3:pcen+3+1,ordcen[pcen,nm]-k]
-                        if np.size(yfit) == 0:
-                            mtfit[sz-k] = 1.0
-                            offchip = True
-                            break
-                        #params, perror, fail = arfitbase.fit_gauss(xfit,yfit)
-                        params, fail = arutils.gauss_fit(xfit,yfit,pcen)
-                        ytfit[sz-k] = params[1]
-                        etfit[sz-k] = 0.02
-                        if fail: mtfit[sz-k] = 1.0
-                        else: pcen = int(0.5+params[1])
-                    if offchip: continue
-                else:
-                    xtfit = np.arange(-sz,sz+1,1.0) # pixel along the arc line
-                    ytfit = np.zeros(2*sz+1) # Fitted centroid
-                    etfit = np.zeros(2*sz+1) # Fitted centroid error
-                    mtfit = np.zeros(2*sz+1) # Mask of bad fits
-                    # Fit up
-                    pcen = pixt[j]
-                    if (pcen < 3) or (pcen > msarc.shape[1]-4): continue
-                    offchip = False
-                    for k in range(0,sz+1):
-                        if (pcen < 3) or (pcen > msarc.shape[0]-4):
-                            offchip == True
-                            break
-                        if ordcen[pcen,nm]+k >= msarc.shape[0]:
-                            mtfit[k+sz] = 1.0
-                            offchip = True
-                            break
-                        xfit = np.arange(pcen-3, pcen+3+1, 1.0)  # 2x3 + 1 = 7 pixels total along the spectral dimension
-                        yfit = msarc[ordcen[pcen,nm]+k,pcen-3:pcen+3+1]
-                        if np.size(yfit) == 0:
-                            mtfit[k+sz] = 1.0
-                            offchip = True
-                            break
-                        #params, perror, fail = arfitbase.fit_gauss(xfit,yfit)
-                        params, fail = arutils.gauss_fit(xfit,yfit,pcen)
-                        ytfit[k+sz] = params[1]
-                        etfit[k+sz] = 0.02
-                        if fail: mtfit[k+sz] = 1.0
-                        else: pcen = int(0.5+params[1])
-                    if offchip: continue
-                    # Fit down
-                    pcen = int(0.5+ytfit[sz]) # Start with the best-fitting centroid at arccen
-                    for k in range(1,sz+1):
-                        if (pcen < 3) or (pcen > msarc.shape[0]-4):
-                            offchip == True
-                            break
-                        if ordcen[pcen,nm]-k < 0:
-                            mtfit[sz-k] = 1.0
-                            offchip = True
-                            break
-                        xfit = np.arange(pcen-3, pcen+3+1, 1.0)
-                        yfit = msarc[ordcen[pcen,nm]-k,pcen-3:pcen+3+1]
-                        if np.size(yfit) == 0:
-                            mtfit[sz-k] = 1.0
-                            offchip = True
-                            break
-                        #params, perror, fail = arfitbase.fit_gauss(xfit,yfit)
-                        params, fail = arutils.gauss_fit(xfit,yfit,pcen)
-                        ytfit[sz-k] = params[1]
-                        etfit[sz-k] = 0.02
-                        if fail: mtfit[sz-k] = 1.0
-                        else: pcen = int(0.5+params[1])
-                    if offchip: continue
+                xtfit = np.arange(-sz,sz+1,1.0) # pixel along the arc line
+                ytfit = np.zeros(2*sz+1) # Fitted centroid
+                etfit = np.zeros(2*sz+1) # Fitted centroid error
+                mtfit = np.zeros(2*sz+1) # Mask of bad fits
+                # Fit up
+                pcen = pixt[j]
+                if (pcen < 3) or (pcen > msarc.shape[0]-4): continue
+                offchip = False
+                for k in range(0,sz+1):
+                    if (pcen < 3) or (pcen > msarc.shape[0]-4):
+                        offchip == True
+                        break
+                    if ordcen[pcen,nm]+k >= msarc.shape[1]:
+                        mtfit[k+sz] = 1.0
+                        offchip = True
+                        break
+                    xfit = np.arange(pcen-3, pcen+3+1, 1.0)  # 2x4 + 1 = 9 pixels total along the spectral dimension
+                    yfit = msarc[pcen-3:pcen+3+1,ordcen[pcen,nm]+k]
+                    if np.size(yfit) == 0:
+                        mtfit[k+sz] = 1.0
+                        offchip = True
+                        break
+                    #params, perror, fail = arfitbase.fit_gauss(xfit,yfit)
+                    params, fail = arutils.gauss_fit(xfit,yfit,pcen)
+                    ytfit[k+sz] = params[1]
+                    etfit[k+sz] = 0.02
+                    if fail: mtfit[k+sz] = 1.0
+                    else: pcen = int(0.5+params[1])
+                if offchip: continue
+                # Fit down
+                pcen = int(0.5+ytfit[sz]) # Start with the best-fitting centroid at arccen
+                for k in range(1,sz+1):
+                    if (pcen < 3) or (pcen > msarc.shape[0]-4):
+                        offchip == True
+                        break
+                    if ordcen[pcen,nm]-k < 0:
+                        mtfit[sz-k] = 1.0
+                        offchip = True
+                        break
+                    xfit = np.arange(pcen-3, pcen+3+1, 1.0)
+                    yfit = msarc[pcen-3:pcen+3+1,ordcen[pcen,nm]-k]
+                    if np.size(yfit) == 0:
+                        mtfit[sz-k] = 1.0
+                        offchip = True
+                        break
+                    #params, perror, fail = arfitbase.fit_gauss(xfit,yfit)
+                    params, fail = arutils.gauss_fit(xfit,yfit,pcen)
+                    ytfit[sz-k] = params[1]
+                    etfit[sz-k] = 0.02
+                    if fail: mtfit[sz-k] = 1.0
+                    else: pcen = int(0.5+params[1])
+                if offchip: continue
                 wmask = np.where(mtfit==0.0)
 #				try:
 #					tcoeff = np.polynomial.polynomial.polyfit(xtfit[wmask],ytfit[wmask],1,w=1.0/mt)
@@ -2158,19 +2078,19 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
                 maskord = np.append(maskord,o)
             else:
                 null, tempc = arutils.robust_polyfit(centval[:,o][w],tiltang[:,o][w], settings.argflag['trace']['slits']['tilts']['disporder'], function=settings.argflag['trace']['slits']['function'],sigma=2.0,
-                                                     minv=0.0, maxv=msarc.shape[slf._dispaxis]-1)
+                                                     minv=0.0, maxv=msarc.shape[0]-1)
                 tcoeff[:,o] = tempc
-#				tcoeff[:,o] = arutils.func_fit(centval[:,o][w],tiltang[:,o][w],settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],min=0.0,max=msarc.shape[slf._dispaxis]-1)
+#				tcoeff[:,o] = arutils.func_fit(centval[:,o][w],tiltang[:,o][w],settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],min=0.0,max=msarc.shape[0]-1)
 #				plt.clf()
 #				plt.plot(centval[:,o][w],tiltang[:,o][w],'bx')
 #				xmod = np.linspace(np.min(centval[:,o][w]),np.max(centval[:,o][w]),1000)
-#				ymod = arutils.func_val(tcoeff[:,o],xmod,settings.argflag['trace']['slits']['function'],min=0.0,max=msarc.shape[slf._dispaxis]-1)
+#				ymod = arutils.func_val(tcoeff[:,o],xmod,settings.argflag['trace']['slits']['function'],min=0.0,max=msarc.shape[0]-1)
 #				plt.plot(xmod,ymod,'r-')
 #		plt.show()
         maskord.sort()
-        xv = np.arange(msarc.shape[slf._dispaxis])
+        xv = np.arange(msarc.shape[0])
         tiltval = arutils.func_val(tcoeff,xv,settings.argflag['trace']['slits']['function'], minv=0.0,
-                                   maxv=msarc.shape[slf._dispaxis]-1).T
+                                   maxv=msarc.shape[0]-1).T
         msgs.work("May need to do a check here to make sure ofit is reasonable")
         ofit = settings.argflag['trace']['slits']['tilts']['params']
         lnpc = len(ofit)-1
@@ -2201,9 +2121,9 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
                     ytiltfit = np.append(ytiltfit,tiltang[:,o][w])
             if np.size(xtiltfit) > settings.argflag['trace']['slits']['tilts']['disporder']+2:
                 tcoeff = arutils.func_fit(xtiltfit,ytiltfit,settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],
-                                          minv=0.0, maxv=msarc.shape[slf._dispaxis]-1)
+                                          minv=0.0, maxv=msarc.shape[0]-1)
                 tiltval = arutils.func_val(tcoeff,xv,settings.argflag['trace']['slits']['function'], minv=0.0,
-                                           maxv=msarc.shape[slf._dispaxis]-1)
+                                           maxv=msarc.shape[0]-1)
                 tilts = tiltval[:,np.newaxis].repeat(tiltang.shape[1],axis=1)
             else:
                 msgs.warn("There are still not enough detections to obtain a reliable tilt trace")
@@ -2224,35 +2144,21 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
 #				plt.clf()
                 # Extract a small region
                 sz = int(np.floor(np.abs(slf._rordloc[pixt[j],i]-slf._lordloc[pixt[j],i])/2.0))-1
-                if slf._dispaxis == 0:
-                    minx, maxx = pixt[j]-4, pixt[j]+4+1
-                    miny, maxy = ordcen[pixt[j],i]-sz, ordcen[pixt[j],i]+sz+1
-                    # Only use arc lines that are entirely on the chip
-                    if (minx < 0) or (maxx > msarc.shape[0]) or (miny < 0) or (maxy > msarc.shape[1]): continue
-# 					if minx < 0: minx = 0
-# 					elif maxx > msarc.shape[0]: maxx = msarc.shape[0]
-# 					if miny < 0: miny = 0
-# 					elif maxy > msarc.shape[1]: maxy = msarc.shape[1]
-                    sqrdata = msarc[minx:maxx,miny:maxy]
-                    # Fit the 2D square region
-                    pos = [miny-ordcen[pixt[j],i],minx-pixt[j],maxy-ordcen[pixt[j],i],maxx-pixt[j]]
-#					pos = [minx-pixt[j],miny-ordcen[pixt[j],i],maxx-pixt[j],maxy-ordcen[pixt[j],i]]
-#					angle, error, fail = arfitbase.fit_tilt(np.rot90(sqrdata), pos, -derv[pixt[j],i])
-                    angle, error, fail = arfitbase.fit_tilt(np.rot90(sqrdata), pos, 0.0)
-                    if not fail: angle *= -1.0
-                else:
-                    minx, maxx = ordcen[pixt[j],i]-sz, ordcen[pixt[j],i]+sz+1
-                    miny, maxy = pixt[j]-4, pixt[j]+4+1
-                    if (minx < 0) or (maxx > msarc.shape[0]) or (miny < 0) or (maxy > msarc.shape[1]): continue
-# 					if minx < 0: minx = 0
-# 					elif maxx > msarc.shape[0]: maxx = msarc.shape[0]
-# 					if miny < 0: miny = 0
-# 					elif maxy > msarc.shape[1]: maxy = msarc.shape[1]
-                    sqrdata = msarc[minx:maxx,miny:maxy]
-                    # Fit the 2D square region
-                    pos = [minx-ordcen[pixt[j],i],miny-pixt[j],maxx-ordcen[pixt[j],i],maxy-pixt[j]]
-#					angle, error, fail = arfitbase.fit_tilt(sqrdata, pos, derv[pixt[j],i])
-                    angle, error, fail = arfitbase.fit_tilt(sqrdata, pos, 0.0)
+                minx, maxx = pixt[j]-4, pixt[j]+4+1
+                miny, maxy = ordcen[pixt[j],i]-sz, ordcen[pixt[j],i]+sz+1
+                # Only use arc lines that are entirely on the chip
+                if (minx < 0) or (maxx > msarc.shape[0]) or (miny < 0) or (maxy > msarc.shape[1]): continue
+# 				if minx < 0: minx = 0
+# 				elif maxx > msarc.shape[0]: maxx = msarc.shape[0]
+# 				if miny < 0: miny = 0
+# 				elif maxy > msarc.shape[1]: maxy = msarc.shape[1]
+                sqrdata = msarc[minx:maxx,miny:maxy]
+                # Fit the 2D square region
+                pos = [miny-ordcen[pixt[j],i],minx-pixt[j],maxy-ordcen[pixt[j],i],maxx-pixt[j]]
+#				pos = [minx-pixt[j],miny-ordcen[pixt[j],i],maxx-pixt[j],maxy-ordcen[pixt[j],i]]
+#				angle, error, fail = arfitbase.fit_tilt(np.rot90(sqrdata), pos, -derv[pixt[j],i])
+                angle, error, fail = arfitbase.fit_tilt(np.rot90(sqrdata), pos, 0.0)
+                if not fail: angle *= -1.0
                 # Save the tilt angle
                 if not fail:
                     tiltang[j,i] = angle
@@ -2271,18 +2177,18 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
             if np.size(w[0]) <= settings.argflag['trace']['slits']['tilts']['disporder']+2:
                 ogd[o] = 0.0
             tcoeff[:,o] = arutils.func_fit(arcdet[:,o][w],tiltang[:,o][w],settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],
-                                           minv=0.0, maxv=msarc.shape[slf._dispaxis]-1)
+                                           minv=0.0, maxv=msarc.shape[0]-1)
         gd = np.where(ogd==1.0)[0]
-        xv = np.arange(msarc.shape[slf._dispaxis])
+        xv = np.arange(msarc.shape[0])
         tiltval = arutils.func_val(tcoeff[:,gd],xv,settings.argflag['trace']['slits']['function'], minv=0.0,
-                                   maxv=msarc.shape[slf._dispaxis]-1).T
+                                   maxv=msarc.shape[0]-1).T
         # Perform a PCA on the tilts
         msgs.info("Performing a PCA on the tilt angles")
         ofit = settings.argflag['trace']['slits']['tilts']['params']
         lnpc = len(ofit)-1
         msgs.work("May need to do a check here to make sure tilt ofit is reasonable")
         coeffs = arutils.func_fit(xv,tiltval,settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],
-                                  minv=0.0, maxv=msarc.shape[slf._dispaxis])
+                                  minv=0.0, maxv=msarc.shape[0])
         xcen = xv[:,np.newaxis].repeat(gd.size,axis=1)
         fitted, outpar = arpca.basis(xcen,tiltval,coeffs,lnpc,ofit,x0in=gd+1.0,skipx0=True,function=settings.argflag['trace']['slits']['function'])
         # If the PCA worked OK, do the following
@@ -2300,7 +2206,7 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
         # Try to find a trace at every arc line
         msgs.info("Tracing tilts")
         w = np.where(maskorder==0)[0]
-        ttiltang, tcentval = arcytrace.trace_tilts(msarc,ordcen,ordsiz[:,w],arcdet,slf._dispaxis,1+2*np.max(ordsiz))
+        ttiltang, tcentval = arcytrace.trace_tilts(msarc,ordcen,ordsiz[:,w],arcdet,1+2*np.max(ordsiz))
         wB = np.where(ttiltang!=-999999.9)
         centval=-999999.9*np.ones((tcentval.shape[0],maskorder.size))
         tiltang=-999999.9*np.ones((ttiltang.shape[0],maskorder.size))
@@ -2348,11 +2254,11 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
                 maskord = np.append(maskord,ow)
             else:
                 tcoeff[:,ow] = arutils.func_fit(centval[:,ow][w],tiltang[:,ow][w],settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],
-                                                minv=0.0, maxv=msarc.shape[slf._dispaxis]-1)
+                                                minv=0.0, maxv=msarc.shape[0]-1)
 #				o += 1
-        xv = np.arange(msarc.shape[slf._dispaxis])
+        xv = np.arange(msarc.shape[0])
         tiltval = arutils.func_val(tcoeff,xv,settings.argflag['trace']['slits']['function'], minv=0.0,
-                                   maxv=msarc.shape[slf._dispaxis]-1).T
+                                   maxv=msarc.shape[0]-1).T
         plt.clf()
         for ow in range(maskorder.size):
             if maskorder[ow] == 1:
@@ -2393,9 +2299,9 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
                     ytiltfit = np.append(ytiltfit,tiltang[:,o][w])
             if np.size(xtiltfit) > settings.argflag['trace']['slits']['tilts']['disporder']+2:
                 tcoeff = arutils.func_fit(xtiltfit,ytiltfit,settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],
-                                          minv=0.0, maxv=msarc.shape[slf._dispaxis]-1)
+                                          minv=0.0, maxv=msarc.shape[0]-1)
                 tiltval = arutils.func_val(tcoeff,xv,settings.argflag['trace']['slits']['function'], minv=0.0,
-                                           maxv=msarc.shape[slf._dispaxis]-1)
+                                           maxv=msarc.shape[0]-1)
                 tilts = tiltval[:,np.newaxis].repeat(tiltang.shape[1],axis=1)
             else:
                 msgs.warn("There are still not enough detections to obtain a reliable tilt trace")
@@ -2410,16 +2316,16 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
             if np.size(w[0]) <= settings.argflag['trace']['slits']['tilts']['disporder']+2:
                 ogd[o] = 0.0
                 continue
-            tcoeff[:,o] = arutils.func_fit(arcdet[:,o][w],tiltang[:,o][w],settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],min=0.0,max=msarc.shape[slf._dispaxis]-1)
+            tcoeff[:,o] = arutils.func_fit(arcdet[:,o][w],tiltang[:,o][w],settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],min=0.0,max=msarc.shape[0]-1)
         gd = np.where(ogd==1.0)[0]
-        xv = np.arange(msarc.shape[slf._dispaxis])
-        tiltval = arutils.func_val(tcoeff[:,gd],xv,settings.argflag['trace']['slits']['function'],min=0.0,max=msarc.shape[slf._dispaxis]-1).T
+        xv = np.arange(msarc.shape[0])
+        tiltval = arutils.func_val(tcoeff[:,gd],xv,settings.argflag['trace']['slits']['function'],min=0.0,max=msarc.shape[0]-1).T
         # Perform a PCA on the tilts
         msgs.info("Performing a PCA on the tilt angles")
         ofit = settings.argflag['trace']['slits']['tilts']['params']
         lnpc = len(ofit)-1
         msgs.bug("May need to do a check here to make sure tilt ofit is reasonable")
-        coeffs = arutils.func_fit(xv,tiltval,settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],min=0.0,max=msarc.shape[slf._dispaxis])
+        coeffs = arutils.func_fit(xv,tiltval,settings.argflag['trace']['slits']['function'],settings.argflag['trace']['slits']['tilts']['disporder'],min=0.0,max=msarc.shape[0])
         xcen = xv[:,np.newaxis].repeat(gd.size,axis=1)
         fitted, outpar = arpca.basis(xcen,tiltval,coeffs,lnpc,ofit,x0in=gd+1.0,skipx0=True,function=settings.argflag['trace']['slits']['function'])
         # If the PCA worked OK, do the following
@@ -2463,10 +2369,7 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
             xmax = ordcen[cv_corr[j,i],nm] + ordwid[cv_corr[j,i],i]
             ymin = incpt + xmin*tilts[cv_corr[j,i],i]
             ymax = incpt + xmax*tilts[cv_corr[j,i],i]
-            if slf._dispaxis == 0:
-                tracereg.write('line({0:.2f},{1:.2f},{2:.2f},{3:.2f}) # line=0 0\n'.format(xmin+1,ymin+1,xmax+1,ymax+1))
-            else:
-                tracereg.write('line({0:.2f},{1:.2f},{2:.2f},{3:.2f}) # line=0 0\n'.format(ymin+1,xmin+1,ymax+1,xmax+1))
+            tracereg.write('line({0:.2f},{1:.2f},{2:.2f},{3:.2f}) # line=0 0\n'.format(xmin+1,ymin+1,xmax+1,ymax+1))
         nm += 1
     tracereg.close()
     # Plot the tilts in real time if the user requests
@@ -2518,14 +2421,12 @@ def trace_tilt(slf, msarc, prefix="", tltprefix="", trcprefix=""):
     return tilts, satsnd
 
 
-def gen_pixloc(dispaxis, frame, det, gen=True):
+def gen_pixloc(frame, det, gen=True):
     """
     Generate an array of physical pixel coordinates
 
     Parameters
     ----------
-    dispaxis : int
-      Dispersion axis
     frame : ndarray
       uniformly illuminated and normalized flat field frame
     det : int
@@ -2543,25 +2444,19 @@ def gen_pixloc(dispaxis, frame, det, gen=True):
     if gen:
         msgs.info("Pixel gap in the dispersion direction = {0:4.3f}".format(settings.spect[dnum]['xgap']))
         msgs.info("Pixel size in the dispersion direction = {0:4.3f}".format(1.0))
-        xs = np.arange(frame.shape[dispaxis]*1.0)*settings.spect[dnum]['xgap']
-        xt = 0.5 + np.arange(frame.shape[dispaxis]*1.0) + xs
+        xs = np.arange(frame.shape[0]*1.0)*settings.spect[dnum]['xgap']
+        xt = 0.5 + np.arange(frame.shape[0]*1.0) + xs
         msgs.info("Pixel gap in the spatial direction = {0:4.3f}".format(settings.spect[dnum]['ygap']))
         msgs.info("Pixel size in the spatial direction = {0:4.3f}".format(settings.spect[dnum]['ysize']))
-        ys = np.arange(frame.shape[1-dispaxis])*settings.spect[dnum]['ygap']*settings.spect[dnum]['ysize']
-        yt = settings.spect[dnum]['ysize']*(0.5 + np.arange(frame.shape[1-dispaxis]*1.0)) + ys
+        ys = np.arange(frame.shape[1])*settings.spect[dnum]['ygap']*settings.spect[dnum]['ysize']
+        yt = settings.spect[dnum]['ysize']*(0.5 + np.arange(frame.shape[1]*1.0)) + ys
         xloc, yloc = np.meshgrid(xt, yt)
 #		xwid, ywid = np.meshgrid(xs,ys)
         msgs.info("Saving pixel locations")
-        if dispaxis == 0:
-            locations[:,:,0] = xloc.T
-            locations[:,:,1] = yloc.T
-            locations[:,:,2] = 1.0
-            locations[:,:,3] = settings.spect[dnum]['ysize']
-        else:
-            locations[:,:,0] = xloc
-            locations[:,:,1] = yloc
-            locations[:,:,2] = 1.0
-            locations[:,:,3] = settings.spect[dnum]['ysize']
+        locations[:,:,0] = xloc.T
+        locations[:,:,1] = yloc.T
+        locations[:,:,2] = 1.0
+        locations[:,:,3] = settings.spect[dnum]['ysize']
     else:
         msgs.error("Have not yet included an algorithm to automatically generate pixel locations")
     return locations
@@ -2591,16 +2486,6 @@ def phys_to_pix(array, pixlocn, axis):
         diff = pixlocn[:,0,0]
     else:
         diff = pixlocn[0,:,1]
-    # if axis == dispaxis:
-    #     if axis == 0:
-    #         diff = pixlocn[:,0,0]
-    #     else:
-    #         diff = pixlocn[0,:,0]
-    # else:
-    #     if axis == 0:
-    #         diff = pixlocn[:,0,1]
-    #     else:
-    #         diff = pixlocn[0,:,1]
     if len(np.shape(array)) == 1:
         pixarr = arcytrace.phys_to_pix(np.array([array]).T, diff).flatten()
     else:


### PR DESCRIPTION
Along with the new parser, I've removed all _horrid_ instances of dispaxis and dispdir throughout the cython and python code. A bug fix that came along with the new parser ensures that the dispaxis/dispdir is always 0 (i.e. the spectral direction is always along the zeroth axis). The development suite runs cleanly.

Algorithmically, the code is unchanged, just cleaned up.