### PR TITLE
Modifications related to LRISr and more

### DIFF
--- a/doc/tracing.rst
+++ b/doc/tracing.rst
@@ -28,6 +28,9 @@ can use a "pinhole" frame to trace the slit centroid.
 User Inputted Values
 ====================
 
+Slit Number
+-----------
+
 When reducing long slit data, it may be a good
 idea to explicitly tell PYPIT that there is only
 1 slit to be identified. You can set this using
@@ -41,6 +44,9 @@ that this feature works best when you have
 well defined and uniformly illuminated slits
 (usually the case with cross dispersed data,
 for example).
+
+Slit Gaps
+---------
 
 In cases where the trace frame contains slits that
 are uniformly illuminated in the spectral direction,
@@ -58,6 +64,9 @@ less than 10 pixels. This variable should not be used unless
 there is some crosstalk between slits, or in the event
 of close slits with a non uniform illumination pattern.
 
+User defined
+------------
+
 If necessary, the user may define the edges of the slit(s)
 on each detector.  Currently this is only implemented for
 single slit (i.e. longslit) mode.  The syntax is to add a
@@ -72,6 +81,19 @@ columns 7-295 on the second detctor::
 
 Because the 2nd value is 0, the code will be required to
 automatically find a slit on the first detector.
+
+Slit Threshold
+--------------
+
+The detection threshold for identifying slits is set
+relatively low to err on finding more than fewer slit edges.
+The algorithm can be fooled by scattered light and detector
+defects.  One can increase the threshold with the *sigdetect*
+parameter::
+
+    trace slits sigdetect 30.
+
+Then monitor the number of slits detected by the algorithm.
 
 Trace frames vs Pinhole frames
 ==============================

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -232,12 +232,14 @@ def setup_param(slf, sc, det, fitsdict):
         else:
             msgs.error('Not ready for this disperser {:s}!'.format(disperser))
     elif sname=='lris_red':
+        debugger.set_trace()
         lamps = ['ArI','NeI','HgI','KrI','XeI']  # Should set according to the lamps that were on
         if disperser == '600/7500':
             arcparam['n_first']=2 # Too much curvature for 1st order
             arcparam['disp']=0.80 # Ang per pixel (unbinned)
             arcparam['b1']= 1./arcparam['disp']/slf._msarc[det-1].shape[0]
             arcparam['wvmnx'][1] = 9000.
+            arcparam['wv_cen'] = 7100.
         elif disperser == '400/8500':
             arcparam['n_first']=2 # Too much curvature for 1st order
             arcparam['disp']=1.16 # Ang per pixel (unbinned)

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -138,7 +138,7 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     return tampl, tcent, twid, w, satsnd, yprep
 
 
-def setup_param(slf, sc, det, fitsdict, allhead):
+def setup_param(slf, sc, det, fitsdict):
     """ Setup for arc analysis
 
     Parameters
@@ -232,7 +232,7 @@ def setup_param(slf, sc, det, fitsdict, allhead):
         else:
             msgs.error('Not ready for this disperser {:s}!'.format(disperser))
     elif sname=='lris_red':
-        arcparam['wv_cen'] = allhead[idx[0]][0]['WAVELEN']
+        arcparam['wv_cen'] = fitsdict['headers'][idx[0]][0]['WAVELEN']
         lamps = ['ArI','NeI','HgI','KrI','XeI']  # Should set according to the lamps that were on
         if disperser == '600/7500':
             arcparam['n_first']=2 # Too much curvature for 1st order

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -138,7 +138,7 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     return tampl, tcent, twid, w, satsnd, yprep
 
 
-def setup_param(slf, sc, det, fitsdict):
+def setup_param(slf, sc, det, fitsdict, allhead):
     """ Setup for arc analysis
 
     Parameters
@@ -232,14 +232,13 @@ def setup_param(slf, sc, det, fitsdict):
         else:
             msgs.error('Not ready for this disperser {:s}!'.format(disperser))
     elif sname=='lris_red':
-        debugger.set_trace()
+        arcparam['wv_cen'] = allhead[idx[0]][0]['WAVELEN']
         lamps = ['ArI','NeI','HgI','KrI','XeI']  # Should set according to the lamps that were on
         if disperser == '600/7500':
             arcparam['n_first']=2 # Too much curvature for 1st order
             arcparam['disp']=0.80 # Ang per pixel (unbinned)
             arcparam['b1']= 1./arcparam['disp']/slf._msarc[det-1].shape[0]
             arcparam['wvmnx'][1] = 9000.
-            arcparam['wv_cen'] = 7100.
         elif disperser == '400/8500':
             arcparam['n_first']=2 # Too much curvature for 1st order
             arcparam['disp']=1.16 # Ang per pixel (unbinned)

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -11,11 +11,7 @@ from pypit import arqa
 from matplotlib import pyplot as plt
 import os
 
-
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/ararclines.py
+++ b/pypit/ararclines.py
@@ -8,10 +8,7 @@ import yaml
 from pypit import armsgs
 from pypit import arparse as settings
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arcoadd.py
+++ b/pypit/arcoadd.py
@@ -15,10 +15,7 @@ from pypit import arload
 from pypit import armsgs
 from pypit import arqa
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arcyarc.pyx
+++ b/pypit/arcyarc.pyx
@@ -968,6 +968,7 @@ def fit_arcorder(np.ndarray[DTYPE_t, ndim=1] xarray not None,
 
     sz_p = pixt.shape[0]
     sz_a = yarray.shape[0]
+    pp = 0
 
     cdef np.ndarray[DTYPE_t, ndim=1] coeff = np.zeros(3, dtype=DTYPE)
     cdef np.ndarray[DTYPE_t, ndim=1] ampl = np.zeros(sz_a, dtype=DTYPE)

--- a/pypit/ardebug.py
+++ b/pypit/ardebug.py
@@ -1,3 +1,7 @@
+from __future__ import (print_function, absolute_import, division, unicode_literals)
+
+from pypit import ginga as pyp_g
+
 def init():
     """
     Returns
@@ -17,3 +21,19 @@ def init():
                  trace_obj=False,
                  )
     return debug
+
+
+def show_image(args, **kwargs):
+    """ Wrapper to pypit_ginga
+    Parameters
+    ----------
+    args
+    kwargs
+
+    Returns
+    -------
+
+    """
+    return pyp_g.show_image(args, **kwargs)
+
+from pdb import *

--- a/pypit/ardebug.py
+++ b/pypit/ardebug.py
@@ -1,6 +1,7 @@
 from __future__ import (print_function, absolute_import, division, unicode_literals)
 
-from pypit import ginga as pyp_g
+# These need to be outside of the def's
+from pypit.ginga import show_image
 
 def init():
     """
@@ -22,7 +23,8 @@ def init():
                  )
     return debug
 
-
+'''
+# GINGA WRAPPERS
 def show_image(args, **kwargs):
     """ Wrapper to pypit_ginga
     Parameters
@@ -35,5 +37,127 @@ def show_image(args, **kwargs):
 
     """
     return pyp_g.show_image(args, **kwargs)
+'''
+
+# ADD-ONs from xastropy
+
+def plot1d(*args,**kwargs):
+    """ Plot 1d arrays
+
+    Parameters
+    ----------
+    outfil= : string
+      Outfil
+    xlbl,ylbl= : string
+      Labels for x,y axes
+    xrng= list
+      Range of x limits
+    yrng= list
+      Range of y limits
+    xtwo= : ndarray
+      x-values for a second array
+    ytwo= : ndarray
+      y-values for a second array
+    mtwo= : str
+      marker for xtwo
+    scatter= : Bool
+      True for a scatter plot
+    NOTE: Any extra parameters are fed as kwargs to plt.plot()
+    """
+    import matplotlib.pyplot as plt
+    import numpy as np
+    # Error checking
+    if len(args) == 0:
+        print('x_guis.simple_splot: No arguments!')
+        return
+
+    if not isinstance(args[0],np.ndarray):
+        print('x_guis: Input array is not a numpy.ndarray!')
+        return
+
+    plt_dict = {}
+
+    # Outfil
+    if ('outfil' in kwargs):
+        plt_dict['outfil'] = kwargs['outfil']
+        kwargs.pop('outfil')
+    else:
+        plt_dict['outfil'] = None
+
+    # Scatter plot?
+    if ('scatter' in kwargs):
+        kwargs.pop('scatter')
+        plt_dict['flg_scatt'] = 1
+    else:
+        plt_dict['flg_scatt'] = 0
+
+    # Second array?
+    if ('xtwo' in kwargs) & ('ytwo' in kwargs):
+        plt_dict['xtwo'] = kwargs['xtwo']
+        kwargs.pop('xtwo')
+        plt_dict['ytwo'] = kwargs['ytwo']
+        kwargs.pop('ytwo')
+        plt_dict['flg_two'] = 1
+        # mtwo
+        if 'mtwo' in kwargs:
+            plt_dict['mtwo']=kwargs['mtwo']
+            kwargs.pop('mtwo')
+        else:
+            plt_dict['mtwo']=''
+    else:
+        plt_dict['flg_two'] = 0
+
+    # Limits
+    for irng in ['xrng','yrng']:
+        try:
+            plt_dict[irng] = kwargs[irng]
+        except KeyError:
+            plt_dict[irng] = None
+        else:
+            kwargs.pop(irng)
+
+    # Labels
+    for ilbl in ['xlbl','ylbl']:
+        try:
+            plt_dict[ilbl] = kwargs[ilbl]
+        except KeyError:
+            plt_dict[ilbl] = None
+        else:
+            kwargs.pop(ilbl)
+
+    # Clear
+    plt.clf()
+    # Plot it right up
+    if len(args) == 1:
+        plt.plot(args[0].flatten(), **kwargs)
+    else:
+        for kk in range(1,len(args)):
+            if plt_dict['flg_scatt'] == 0:
+                plt.plot(args[0].flatten(),args[kk].flatten(), **kwargs)
+            else:
+                plt.scatter(args[0].flatten(),args[kk].flatten(), marker='o', **kwargs)
+
+    if plt_dict['flg_two'] == 1:
+        plt.plot(plt_dict['xtwo'], plt_dict['ytwo'], plt_dict['mtwo'], color='red', **kwargs)
+
+    # Limits
+    if plt_dict['xrng'] is not None:
+        plt.xlim(plt_dict['xrng'])
+    if plt_dict['yrng'] is not None:
+        plt.ylim(plt_dict['yrng'])
+
+    # Label
+    if plt_dict['xlbl'] is not None:
+        plt.xlabel(plt_dict['xlbl'])
+    if plt_dict['ylbl'] is not None:
+        plt.ylabel(plt_dict['ylbl'])
+
+    # Output?
+    if plt_dict['outfil'] is not None:
+        plt.savefig(plt_dict['outfil'])
+        print('Wrote figure to {:s}'.format(plt_dict['outfil']))
+    else: # Show
+        plt.show()
+    return
 
 from pdb import *

--- a/pypit/ardebug.py
+++ b/pypit/ardebug.py
@@ -23,25 +23,8 @@ def init():
                  )
     return debug
 
-'''
-# GINGA WRAPPERS
-def show_image(args, **kwargs):
-    """ Wrapper to pypit_ginga
-    Parameters
-    ----------
-    args
-    kwargs
-
-    Returns
-    -------
-
-    """
-    return pyp_g.show_image(args, **kwargs)
-'''
-
 # ADD-ONs from xastropy
-
-def plot1d(*args,**kwargs):
+def plot1d(*args, **kwargs):
     """ Plot 1d arrays
 
     Parameters

--- a/pypit/arextract.py
+++ b/pypit/arextract.py
@@ -11,10 +11,7 @@ from pypit import arqa
 # Logging
 msgs = armsgs.get_logger()
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # MASK VALUES FROM EXTRACTION
 # 0 

--- a/pypit/arflux.py
+++ b/pypit/arflux.py
@@ -19,10 +19,7 @@ try:
 except ImportError:
     pass
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arload.py
+++ b/pypit/arload.py
@@ -17,10 +17,7 @@ try:
 except NameError:
     basestring = str
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arlris.py
+++ b/pypit/arlris.py
@@ -8,10 +8,7 @@ import astropy.io.fits as pyfits
 from pypit import armsgs
 from pypit.arparse import load_sections
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/armasters.py
+++ b/pypit/armasters.py
@@ -8,11 +8,7 @@ from pypit import arsave
 # Logging
 msgs = armsgs.get_logger()
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
-
+from pypit import ardebug as debugger
 
 class MasterFrames:
 

--- a/pypit/armbase.py
+++ b/pypit/armbase.py
@@ -16,10 +16,7 @@ from pypit import arutils
 # Logging
 msgs = armsgs.get_logger()
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 
 def SetupScience(fitsdict):

--- a/pypit/armed.py
+++ b/pypit/armed.py
@@ -14,10 +14,7 @@ from pypit import arsort
 from pypit import artrace
 from pypit import arqa
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/armlsd.py
+++ b/pypit/armlsd.py
@@ -147,7 +147,7 @@ def ARMLSD(fitsdict, reuseMaster=False, reloadMaster=True):
 
             ###############
             # Generate the 1D wavelength solution
-            update = slf.MasterWaveCalib(fitsdict, sc, det, allhead)
+            update = slf.MasterWaveCalib(fitsdict, sc, det)
             if update and reuseMaster:
                 armbase.UpdateMasters(sciexp, sc, det, ftype="arc", chktype="trace")
             #debugger.set_trace()
@@ -215,7 +215,7 @@ def ARMLSD(fitsdict, reuseMaster=False, reloadMaster=True):
                 msgs.work("Include the facility to correct for gravitational redshifts and time delays (see Pulsar timing work)")
                 msgs.info("Performing a heliocentric correction")
                 # Load the header for the science frame
-                slf._waveids = arvcorr.helio_corr(slf, scidx[0])
+                #slf._waveids = arvcorr.helio_corr(slf, scidx[0])
             else:
                 msgs.info("A heliocentric correction will not be performed")
 

--- a/pypit/armlsd.py
+++ b/pypit/armlsd.py
@@ -146,7 +146,7 @@ def ARMLSD(fitsdict, allhead, reuseMaster=False, reloadMaster=True):
 
             ###############
             # Generate the 1D wavelength solution
-            update = slf.MasterWaveCalib(fitsdict, sc, det)
+            update = slf.MasterWaveCalib(fitsdict, sc, det, allhead)
             if update and reuseMaster:
                 armbase.UpdateMasters(sciexp, sc, det, ftype="arc", chktype="trace")
             #debugger.set_trace()

--- a/pypit/armlsd.py
+++ b/pypit/armlsd.py
@@ -76,7 +76,6 @@ def ARMLSD(fitsdict, reuseMaster=False, reloadMaster=True):
         if reloadMaster and (sc > 0):
             settings.argflag['reduce']['masters']['reuse'] = True
         # Loop on Detectors
-        #for kk in range(1,settings.spect['mosaic']['ndet']):
         for kk in range(settings.spect['mosaic']['ndet']):
             det = kk + 1  # Detectors indexed from 1
             slf.det = det

--- a/pypit/armlsd.py
+++ b/pypit/armlsd.py
@@ -76,7 +76,8 @@ def ARMLSD(fitsdict, allhead, reuseMaster=False, reloadMaster=True):
         if reloadMaster and (sc > 0):
             settings.argflag['reduce']['masters']['reuse'] = True
         # Loop on Detectors
-        for kk in range(settings.spect['mosaic']['ndet']):
+        #for kk in range(settings.spect['mosaic']['ndet']):
+        for kk in range(1,settings.spect['mosaic']['ndet']):
             det = kk + 1  # Detectors indexed from 1
             slf.det = det
             ###############

--- a/pypit/armlsd.py
+++ b/pypit/armlsd.py
@@ -76,8 +76,8 @@ def ARMLSD(fitsdict, allhead, reuseMaster=False, reloadMaster=True):
         if reloadMaster and (sc > 0):
             settings.argflag['reduce']['masters']['reuse'] = True
         # Loop on Detectors
-        #for kk in range(settings.spect['mosaic']['ndet']):
-        for kk in range(1,settings.spect['mosaic']['ndet']):
+        #for kk in range(1,settings.spect['mosaic']['ndet']):
+        for kk in range(settings.spect['mosaic']['ndet']):
             det = kk + 1  # Detectors indexed from 1
             slf.det = det
             ###############

--- a/pypit/armlsd.py
+++ b/pypit/armlsd.py
@@ -17,10 +17,7 @@ from pypit import arqa
 
 from linetools import utils as ltu
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arpca.py
+++ b/pypit/arpca.py
@@ -6,10 +6,7 @@ from pypit import armsgs
 from pypit import arutils
 from pypit.arqa import get_dimen as get_dimen
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -1162,18 +1162,6 @@ def sub_overscan(frame, det):
     dnum = settings.get_dnum(det)
 
     for i in range(settings.spect[dnum]['numamplifiers']):
-        # Determine the section of the chip that contains the overscan region
-        oscansec = "oscansec{0:02d}".format(i+1)
-        ox0, ox1 = settings.spect[dnum][oscansec][0][0], settings.spect[dnum][oscansec][0][1]
-        oy0, oy1 = settings.spect[dnum][oscansec][1][0], settings.spect[dnum][oscansec][1][1]
-        if ox0 < 0: ox0 += frame.shape[0]
-        if ox1 <= 0: ox1 += frame.shape[0]
-        if oy0 < 0: oy0 += frame.shape[1]
-        if oy1 <= 0: oy1 += frame.shape[1]
-        xos = np.arange(ox0, ox1)
-        yos = np.arange(oy0, oy1)
-        w = np.ix_(xos, yos)
-        oscan = frame[w]
         # Determine the section of the chip that contains data
         datasec = "datasec{0:02d}".format(i+1)
         dx0, dx1 = settings.spect[dnum][datasec][0][0], settings.spect[dnum][datasec][0][1]
@@ -1184,6 +1172,18 @@ def sub_overscan(frame, det):
         if dy1 <= 0: dy1 += frame.shape[1]
         xds = np.arange(dx0, dx1)
         yds = np.arange(dy0, dy1)
+        # Determine the section of the chip that contains the overscan region
+        oscansec = "oscansec{0:02d}".format(i+1)
+        ox0, ox1 = settings.spect[dnum][oscansec][0][0], settings.spect[dnum][oscansec][0][1]
+        oy0, oy1 = settings.spect[dnum][oscansec][1][0], settings.spect[dnum][oscansec][1][1]
+        if ox0 < 0: ox0 += frame.shape[0]
+        if ox1 <= 0: ox1 += min(frame.shape[0], dx1)  # Truncate to datasec
+        if oy0 < 0: oy0 += frame.shape[1]
+        if oy1 <= 0: oy1 += min(frame.shape[1], dy1)  # Truncate to datasec
+        xos = np.arange(ox0, ox1)
+        yos = np.arange(oy0, oy1)
+        w = np.ix_(xos, yos)
+        oscan = frame[w]
         # Make sure the overscan section has at least one side consistent with datasec
         if dx1-dx0 == ox1-ox0:
             osfit = np.median(oscan, axis=1)  # Mean was hit by CRs

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -16,10 +16,7 @@ from pypit import arqa
 from pypit import arpca
 from pypit import arwave
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arqa.py
+++ b/pypit/arqa.py
@@ -671,9 +671,9 @@ def slit_trace_qa(slf, frame, ltrace, rtrace, extslit, desc="", root='trace', ou
         else:
             ptyp = '--'
         # Left
-        plt.plot(ltrace[:, ii]+0.5, ycen, 'r'+ptyp, linewidth=0.1, alpha=0.7)
+        plt.plot(ltrace[:, ii]+0.5, ycen, 'r'+ptyp, linewidth=0.3, alpha=0.7)
         # Right
-        plt.plot(rtrace[:, ii]+0.5, ycen, 'c'+ptyp, linewidth=0.1, alpha=0.7)
+        plt.plot(rtrace[:, ii]+0.5, ycen, 'c'+ptyp, linewidth=0.3, alpha=0.7)
         # Label
         #plt.text(ltrace[iy, ii], ycen[iy], '{0:d}'.format(ii+1), color='red', ha='left')
         plt.text(0.5*(ltrace[iy, ii]+rtrace[iy, ii]), ycen[iy], '{0:d}'.format(ii+1), color='green', ha='center', size='small')

--- a/pypit/arqa.py
+++ b/pypit/arqa.py
@@ -23,10 +23,7 @@ plt.rcParams['font.family']= 'times new roman'
 ticks_font = matplotlib.font_manager.FontProperties(family='times new roman',
                                                     style='normal', size=16, weight='normal', stretch='normal')
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 
 def arc_fit_qa(slf, fit, outfil=None, ids_only=False, title=None):

--- a/pypit/arsave.py
+++ b/pypit/arsave.py
@@ -14,10 +14,7 @@ import h5py
 from pypit import armsgs
 from pypit import arparse as settings
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arsciexp.py
+++ b/pypit/arsciexp.py
@@ -20,10 +20,7 @@ from pypit import arproc
 from pypit import arsort
 from pypit import arutils
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 # Logging
 msgs = armsgs.get_logger()

--- a/pypit/arsciexp.py
+++ b/pypit/arsciexp.py
@@ -645,7 +645,7 @@ class ScienceExposure:
         del mswave
         return True
 
-    def MasterWaveCalib(self, fitsdict, sc, det):
+    def MasterWaveCalib(self, fitsdict, sc, det, allhead):
         """
         Generate Master 1D Wave Solution (down slit center)
 
@@ -681,7 +681,7 @@ class ScienceExposure:
         # if False and 'wave_calib'+settings.argflag['reduce']['masters']['setup'] not in settings.argflag['reduce']['masters']['loaded']:
         if 'wave_calib' + settings.argflag['reduce']['masters']['setup'] not in settings.argflag['reduce']['masters']['loaded']:
             # Setup arc parameters (e.g. linelist)
-            arcparam = ararc.setup_param(self, sc, det, fitsdict)
+            arcparam = ararc.setup_param(self, sc, det, fitsdict, allhead)
             self.SetFrame(self._arcparam, arcparam, det)
             ###############
             # Extract arc and identify lines

--- a/pypit/arsciexp.py
+++ b/pypit/arsciexp.py
@@ -645,7 +645,7 @@ class ScienceExposure:
         del mswave
         return True
 
-    def MasterWaveCalib(self, fitsdict, sc, det, allhead):
+    def MasterWaveCalib(self, fitsdict, sc, det):
         """
         Generate Master 1D Wave Solution (down slit center)
 
@@ -681,7 +681,7 @@ class ScienceExposure:
         # if False and 'wave_calib'+settings.argflag['reduce']['masters']['setup'] not in settings.argflag['reduce']['masters']['loaded']:
         if 'wave_calib' + settings.argflag['reduce']['masters']['setup'] not in settings.argflag['reduce']['masters']['loaded']:
             # Setup arc parameters (e.g. linelist)
-            arcparam = ararc.setup_param(self, sc, det, fitsdict, allhead)
+            arcparam = ararc.setup_param(self, sc, det, fitsdict)
             self.SetFrame(self._arcparam, arcparam, det)
             ###############
             # Extract arc and identify lines

--- a/pypit/arsort.py
+++ b/pypit/arsort.py
@@ -18,10 +18,8 @@ from astropy import units as u
 
 from linetools import utils as ltu
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
+
 try:
     basestring
 except NameError:

--- a/pypit/arspecobj.py
+++ b/pypit/arspecobj.py
@@ -10,10 +10,7 @@ from pypit import armsgs
 # Logging
 msgs = armsgs.get_logger()
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 class SpecObjExp(object):
     """Class to handle object spectra from a single exposure

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -933,7 +933,6 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     else: # There's an order overlap
         rsub = edgbtwn[1]-(lval)
     """
-    debugger.set_trace()
     if mnvalp > mnvalm:
         lvp = (arutils.func_val(lcoeff[:, lval+1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -18,9 +18,6 @@ from collections import Counter
 # Logging
 msgs = armsgs.get_logger()
 
-#try:
-#    from xastropy.xutils import xdebug as debugger
-#except ImportError:
 from pypit import ardebug as debugger
 
 

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -933,6 +933,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     else: # There's an order overlap
         rsub = edgbtwn[1]-(lval)
     """
+    debugger.set_trace()
     if mnvalp > mnvalm:
         lvp = (arutils.func_val(lcoeff[:, lval+1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)
@@ -994,7 +995,10 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     msgs.info("Relabelling slit edges")
     rsub = int(round(rsub))
     msgs.warn("KLUDGE HERE")
-    rsub = -1
+    if det == 1:
+        rsub = -1
+    else:
+        debugger.set_trace()
     if lmin < rmin-rsub:
         esub = lmin - (settings.argflag['trace']['slits']['pca']['extrapolate']['neg']+1)
     else:

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -1042,11 +1042,6 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
 #			rva = rvb
     msgs.info("Relabelling slit edges")
     rsub = int(round(rsub))
-    msgs.warn("KLUDGE HERE")
-    if det == 1:
-        rsub = -1
-    else:
-        debugger.set_trace()
     if lmin < rmin-rsub:
         esub = lmin - (settings.argflag['trace']['slits']['pca']['extrapolate']['neg']+1)
     else:

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -18,10 +18,10 @@ from collections import Counter
 # Logging
 msgs = armsgs.get_logger()
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+#try:
+#    from xastropy.xutils import xdebug as debugger
+#except ImportError:
+from pypit import ardebug as debugger
 
 
 def assign_slits(binarr, edgearr, ednum=100000, lor=-1):
@@ -908,10 +908,9 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     msgs.info("Synchronizing left and right slit traces")
     # Define the array of pixel values along the dispersion direction
     xv = plxbin[:, 0]
-    num = (lmax-lmin)/2
+    num = (lmax-lmin)//2  # Should be an int, right?
     lval = lmin + num  # Pick an order, somewhere in between lmin and lmax
-    lv = (arutils.func_val(lcoeff[:, lval-lmin], xv, settings.argflag['trace']['slits']['function'],
-                           minv=minvf, maxv=maxvf)+0.5).astype(np.int)
+    lv = (arutils.func_val(lcoeff[:, lval-lmin], xv, settings.argflag['trace']['slits']['function'], minv=minvf, maxv=maxvf)+0.5).astype(np.int)
     if np.any(lv < 0) or np.any(lv+1 >= binarr.shape[1]):
         msgs.warn("At least one slit is poorly traced")
         msgs.info("Refer to the manual, and adjust the input trace parameters")
@@ -994,6 +993,8 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
 #			rva = rvb
     msgs.info("Relabelling slit edges")
     rsub = int(round(rsub))
+    msgs.warn("KLUDGE HERE")
+    rsub = -1
     if lmin < rmin-rsub:
         esub = lmin - (settings.argflag['trace']['slits']['pca']['extrapolate']['neg']+1)
     else:
@@ -1075,7 +1076,8 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
         xcen = xv[:, np.newaxis].repeat(ordsnd.size, axis=1)
         fitted, outpar = arpca.basis(xcen, slitcen, coeffs, lnpc, ofit, x0in=ordsnd, mask=maskord,
                                      skipx0=False, function=settings.argflag['trace']['slits']['function'])
-        arpca.pc_plot(slf, outpar, ofit, pcadesc=pcadesc)
+        if not msgs._debug['no_qa']:
+            arpca.pc_plot(slf, outpar, ofit, pcadesc=pcadesc)
         # Extrapolate the remaining orders requested
         orders = 1.0+np.arange(totord)
         extrap_cent, outpar = arpca.extrapolate(outpar, orders, function=settings.argflag['trace']['slits']['function'])
@@ -1142,7 +1144,8 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
             fitted, outpar = arpca.basis(xcen, trcval, tcoeff, lnpc, ofit, weights=pxwght,
                                          x0in=ordsnd, mask=maskrw, skipx0=False,
                                          function=settings.argflag['trace']['slits']['function'])
-            arpca.pc_plot(slf, outpar, ofit, pcadesc=pcadesc, addOne=False)
+            if not msgs._debug['no_qa']:
+                arpca.pc_plot(slf, outpar, ofit, pcadesc=pcadesc, addOne=False)
             # Now extrapolate to the whole detector
             pixpos = np.arange(binarr.shape[1])
             extrap_trc, outpar = arpca.extrapolate(outpar, pixpos,
@@ -1203,6 +1206,11 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     # plt.close()
 
     # Illustrate where the orders fall on the detector (physical units)
+    if msgs._debug['trace']:
+        from pypit import ginga
+        viewer, ch = ginga.show_image(mstrace)
+        ginga.show_slits(viewer, ch, lcenint, rcenint)
+        debugger.set_trace()
     if settings.argflag['run']['qa']:
         msgs.work("Not yet setup with ginga")
     return lcenint, rcenint, extrapord
@@ -1787,12 +1795,14 @@ def echelle_tilt(slf, msarc, det, pcadesc="PCA trace of the spectral tilts", mas
         xcen = xv[:, np.newaxis].repeat(norders, axis=1)
         fitted, outpar = arpca.basis(xcen, tiltval, tcoeff, lnpc, ofit, x0in=ordsnd, mask=maskord, skipx0=False,
                                      function=settings.argflag['trace']['slits']['function'])
-        arpca.pc_plot(slf, outpar, ofit, pcadesc=pcadesc)
+        if not msgs._debug['no_qa']:
+            arpca.pc_plot(slf, outpar, ofit, pcadesc=pcadesc)
         # Extrapolate the remaining orders requested
         orders = 1.0 + np.arange(norders)
         extrap_tilt, outpar = arpca.extrapolate(outpar, orders, function=settings.argflag['trace']['slits']['function'])
         tilts = extrap_tilt
-        arpca.pc_plot_arctilt(slf, tiltang, centval, tilts)
+        if not msgs._debug['no_qa']:
+            arpca.pc_plot_arctilt(slf, tiltang, centval, tilts)
     else:
         outpar = None
         msgs.warn("Could not perform a PCA when tracing the order tilts" + msgs.newline() +
@@ -1988,7 +1998,8 @@ def multislit_tilt(slf, msarc, det, maskval=-999999.9):
             fitted, outpar = arpca.basis(xcen, tiltval, tcoeff, lnpc, ofit, weights=None,
                                          x0in=ordsnd, mask=maskrw, skipx0=False,
                                          function=settings.argflag['trace']['slits']['function'])
-            arpca.pc_plot(slf, outpar, ofit, pcadesc="Spectral Tilts PCA", addOne=False)
+            if not msgs._debug['no_qa']:
+                arpca.pc_plot(slf, outpar, ofit, pcadesc="Spectral Tilts PCA", addOne=False)
             # Extrapolate the remaining orders requested
             orders = np.linspace(0.0, 1.0, msarc.shape[0])
             extrap_tilt, outpar = arpca.extrapolate(outpar, orders, function=settings.argflag['trace']['slits']['function'])

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -954,7 +954,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False):
     msgs.info("Synchronizing left and right slit traces")
     # Define the array of pixel values along the dispersion direction
     xv = plxbin[:, 0]
-    num = (lmax-lmin)//2  # Should be an int, right?
+    num = (lmax-lmin)//2
     lval = lmin + num  # Pick an order, somewhere in between lmin and lmax
     lv = (arutils.func_val(lcoeff[:, lval-lmin], xv, settings.argflag['trace']['slits']['function'], minv=minvf, maxv=maxvf)+0.5).astype(np.int)
     if np.any(lv < 0) or np.any(lv+1 >= binarr.shape[1]):

--- a/pypit/arutils.py
+++ b/pypit/arutils.py
@@ -13,15 +13,10 @@ from pypit import armsgs
 #from pypit import arcyarc
 import warnings
 
-#from xastropy.xutils import xdebug as xdb
-
 # Logging
 msgs = armsgs.get_logger()
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 try:
     basestring

--- a/pypit/arwave.py
+++ b/pypit/arwave.py
@@ -17,10 +17,7 @@ from pypit import arutils
 # Logging
 msgs = armsgs.get_logger()
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 
 def flex_shift(slf, det, obj_skyspec, arx_skyspec):

--- a/pypit/ginga.py
+++ b/pypit/ginga.py
@@ -8,7 +8,8 @@ import numpy as np
 from pypit import armsgs
 from pypit import pyputils
 
-from pypit import ardebug as debugger
+# CANNOT LOAD DEBUGGER AS THIS MODULE IS CALLED BY ARDEBUG
+#from pypit import ardebug as debugger
 
 try:
     basestring

--- a/pypit/ginga.py
+++ b/pypit/ginga.py
@@ -8,10 +8,8 @@ import numpy as np
 from pypit import armsgs
 from pypit import pyputils
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
+
 try:
     basestring
 except NameError:

--- a/pypit/pypit.py
+++ b/pypit/pypit.py
@@ -15,10 +15,7 @@ try:
 except ImportError:
     pass
 
-try:
-    from xastropy.xutils import xdebug as debugger
-except ImportError:
-    import pdb as debugger
+from pypit import ardebug as debugger
 
 
 def PYPIT(redname, debug=None, progname=__file__, quick=False, ncpus=1, verbosity=1,

--- a/pypit/scripts/show_twod.py
+++ b/pypit/scripts/show_twod.py
@@ -64,7 +64,7 @@ def main(args):
     trc_hdu = fits.open(trc_file)
     lordloc = trc_hdu[1].data  # Should check name
     rordloc = trc_hdu[2].data  # Should check name
-    pyp_ginga.show_slits(viewer, ch, lordloc, rordloc, args.det)
+    pyp_ginga.show_slits(viewer, ch, lordloc, rordloc)#, args.det)
 
     # Object traces
     spec1d_file = args.file.replace('spec2d', 'spec1d')

--- a/pypit/scripts/show_twod.py
+++ b/pypit/scripts/show_twod.py
@@ -6,13 +6,13 @@
 
 """
 This script enables the viewing of a processed FITS file
-with extras
+with extras.  Run above the Science/ folder.
 """
 
 def parser(options=None):
     import argparse
 
-    parser = argparse.ArgumentParser(description='Display spec2d image in a Ginga viewer',
+    parser = argparse.ArgumentParser(description='Display spec2d image in a Ginga viewer.  Run above the Science/ folder',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('file', type = str, default = None, help = 'PYPIT spec2d file')


### PR DESCRIPTION
Several changes, somewhat related to LRISr.  Here they are:

- Docs on trace slits sigdetect
- Reads wv_cen from LRIS header ('WAVELEN')
- Turns ardebug.py into our debugger.  If this is approved, I will remove the xastropy debugger
- Adds hooks in ardebug to ginga routines, e.g. show_image()
- Fixes oscansec issue with LRISr
- Adds additional no_qa checks

A few other bits and pieces. 
No new tests.