### PR TITLE
Reducing CRs in Object Identification

### DIFF
--- a/doc/calibrations.rst
+++ b/doc/calibrations.rst
@@ -1,15 +1,15 @@
 .. highlight:: rest
 
-============
-Calibrations
-============
+====================
+Calibration Overview
+====================
 
 This document gives an overview of the calibration
 steps of PYPIT.  There is additional documentation
 for several of the more complex steps.
 
-Overview
-========
+Sequence of Events
+==================
 
 Here is the sequence of events:
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -53,6 +53,17 @@ Calibrations
    :maxdepth: 2
 
    calibrations
+   bias
+   tracing
+   wave_calib
+
+Object Algorithms
++++++++++++++++++
+
+.. toctree::
+   :maxdepth: 2
+
+   object_id
 
 Documentation
 +++++++++++++
@@ -60,11 +71,8 @@ Documentation
 .. toctree::
    :maxdepth: 1
 
-   bias
    flexure
    frametype
-   tracing
-   wave_calib
 
 Other
 +++++

--- a/doc/object_id.rst
+++ b/doc/object_id.rst
@@ -1,0 +1,57 @@
+.. highlight:: rest
+
+*********************
+Object Identification
+*********************
+
+This document will describe how the code identifies
+objects within the slits.
+
+Overview
+========
+
+Object identification is a challenging process to
+code, especially to allow for a large dynamic range
+between bright continuum sources and faint emission
+line sources.   Our general philosophy has been to
+err on the faint side, i.e. aggressively
+detect sources aggressively with the side-effect of
+including false positives.
+
+Algorithms
+==========
+
+Standard
+--------
+
+The standard algorithm performs the following steps:
+
+1. Rectify the sky-subtracted frame
+
+2. Smooth this 2D image
+
+3. Perform sigma clipping (median stat) down the wavelength
+dimension to further reject CRs.  This may eliminate bright
+emission lines.
+
+4.  Smash the 2D image into a 1D array aligned with the
+slit (i.e. spatial dimension).
+
+5.  Perform an initial search for objects by fitting a low-order
+polynomial to the slit array and associate objects with pixels
+that are deviant with that fit.
+
+6.  Estimate the scatter in the slit array and then
+define all 5 sigma, positive excursion as objects (with
+3 sigma edges).
+
+7.  Eliminate any objects within a few percent of the slit edge.
+
+8.  Optional: Restrict to maximum number of input objects,
+ ordered by flux.
+
+By-hand
+-------
+
+Object Tracing
+==============

--- a/doc/object_id.rst
+++ b/doc/object_id.rst
@@ -32,9 +32,9 @@ The standard algorithm performs the following steps:
 
 3. Perform sigma clipping (median stat) down the wavelength dimension to further reject CRs.  This may eliminate bright emission lines.
 
-4.  Smash the 2D image into a 1D array aligned with the slit (i.e. spatial dimension).
+4.  Smash the 2D image along the spectral dimension, to get a 1D array that represents the spatial profile of the exposure.
 
-5.  Perform an initial search for objects by fitting a low-order polynomial to the slit array and associate objects with pixels that are deviant with that fit.
+5.  Perform an initial search for objects by fitting a low-order polynomial to the spatial profile and associate objects with pixels that are deviant with that fit.
 
 6.  Estimate the scatter in the slit array and then define all 5 sigma, positive excursion as objects (with 3 sigma edges).
 

--- a/doc/object_id.rst
+++ b/doc/object_id.rst
@@ -30,25 +30,17 @@ The standard algorithm performs the following steps:
 
 2. Smooth this 2D image
 
-3. Perform sigma clipping (median stat) down the wavelength
-dimension to further reject CRs.  This may eliminate bright
-emission lines.
+3. Perform sigma clipping (median stat) down the wavelength dimension to further reject CRs.  This may eliminate bright emission lines.
 
-4.  Smash the 2D image into a 1D array aligned with the
-slit (i.e. spatial dimension).
+4.  Smash the 2D image into a 1D array aligned with the slit (i.e. spatial dimension).
 
-5.  Perform an initial search for objects by fitting a low-order
-polynomial to the slit array and associate objects with pixels
-that are deviant with that fit.
+5.  Perform an initial search for objects by fitting a low-order polynomial to the slit array and associate objects with pixels that are deviant with that fit.
 
-6.  Estimate the scatter in the slit array and then
-define all 5 sigma, positive excursion as objects (with
-3 sigma edges).
+6.  Estimate the scatter in the slit array and then define all 5 sigma, positive excursion as objects (with 3 sigma edges).
 
 7.  Eliminate any objects within a few percent of the slit edge.
 
-8.  Optional: Restrict to maximum number of input objects,
- ordered by flux.
+8.  Optional: Restrict to maximum number of input objects, ordered by flux.
 
 By-hand
 -------

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -951,7 +951,8 @@ def sn_frame(slf, sciframe, idx):
     return snframe
 
 
-def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-999999.9):
+def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-999999.9,
+             simple_var=False):
     """
     Identify cosmic rays using the L.A.Cosmic algorithm
     U{http://www.astro.yale.edu/dokkum/lacosmic/}
@@ -999,7 +1000,10 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
         msgs.info("Creating noise model")
         # Build a custom noise map, and compare  this to the laplacian
         m5 = ndimage.filters.median_filter(scicopy, size=5, mode='mirror')
-        noise = np.sqrt(variance_frame(slf, det, m5, scidx, fitsdict))
+        if simple_var:
+            noise = np.sqrt(np.abs(m5)) #variance_frame(slf, det, m5, scidx, fitsdict))
+        else:
+            noise = np.sqrt(variance_frame(slf, det, m5, scidx, fitsdict))
         msgs.info("Calculating Laplacian signal to noise ratio")
 
         # Laplacian S/N

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -379,6 +379,7 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
     med, mad = arutils.robust_meanstd(trcprof[wm])
     trcprof -= med
     objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+    debugger.set_trace()
     #plt.clf()
     #plt.plot(trcxrng,trcprof,'k-')
     #wl = np.where(bckl[:,0]==1)

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -22,6 +22,7 @@ msgs = armsgs.get_logger()
 #    from xastropy.xutils import xdebug as debugger
 #except ImportError:
 from pypit import ardebug as debugger
+from xastropy.xutils import xdebug as xdb
 
 
 def assign_slits(binarr, edgearr, ednum=100000, lor=-1):
@@ -301,7 +302,8 @@ def expand_slits(slf, mstrace, det, ordcen, extord):
 
 def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
                  triml=None, trimr=None, sigmin=2.0, bgreg=None,
-                 maskval=-999999.9, order=0, doqa=True):
+                 maskval=-999999.9, order=0, doqa=True,
+                 xedge=0.03, fwhm=3.):
     """ Finds objects, and traces their location on the detector
     Parameters
     ----------
@@ -316,6 +318,8 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
     bgreg
     maskval
     order
+    xedge : float
+      Trim objects within xedge % of the slit edge
     doqa
 
     Returns
@@ -323,6 +327,7 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
 
     """
     from pypit import arcytrace
+    from pypit import arproc
     from pypit import arcyutils
     smthby = 7
     rejhilo = 1
@@ -364,8 +369,12 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
     srtsig = np.sort(rec_sigframe_bin,axis=1)
     ww = np.where(srtsig[:,-2] > med + sigmin*mad)
     mask_sigframe = np.ma.array(rec_sigframe_bin, mask=rec_crmask, fill_value=maskval)
+    # Clip image along spatial dimension -- May eliminate bright emission lines
+    from astropy.stats import sigma_clip
+    clip_image = sigma_clip(mask_sigframe[ww[0],:], axis=0, sigma=4.)
     # Collapse along the spectral direction to get object profile
-    trcprof = np.ma.mean(mask_sigframe[ww[0],:], axis=0).filled(0.0)
+    #trcprof = np.ma.mean(mask_sigframe[ww[0],:], axis=0).filled(0.0)
+    trcprof = np.ma.mean(clip_image, axis=0).filled(0.0)
     trcxrng = np.arange(npix)/(npix-1.0)
     msgs.info("Identifying objects that are significantly detected")
     # Find significantly detected objects
@@ -378,20 +387,23 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
         return None
     med, mad = arutils.robust_meanstd(trcprof[wm])
     trcprof -= med
+    # Gaussian smooth
+    #from scipy.ndimage.filters import gaussian_filter1d
+    #smth_prof = gaussian_filter1d(trcprof, fwhm/2.35)
+    # Define all 5 sigma deviations as objects (should make the 5 user-defined)
+    #objl, objr, bckl, bckr = arcytrace.find_objects(smth_prof, bgreg, mad)
     objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
-    debugger.set_trace()
-    #plt.clf()
-    #plt.plot(trcxrng,trcprof,'k-')
-    #wl = np.where(bckl[:,0]==1)
-    #plt.plot(trcxrng[wl],trcprof[wl],'ro')
-    #wr = np.where(bckr[:,0]==1)
-    #plt.plot(trcxrng[wr],trcprof[wr],'go')
-    #plt.plot(trcxrng[objl[0]:objr[0]+1],trcprof[objl[0]:objr[0]+1],'bx')
-    #plt.show()
+    # Remove objects within x percent of the slit edge
+    xp = (objr+objl)/float(trcprof.size)/2.
+    gdobj = (xp < (1-xedge)) * (xp > xedge)
+    objl = objl[gdobj]
+    objr = objr[gdobj]
+    bckl = bckl[:,gdobj]
+    bckr = bckr[:,gdobj]
+    if np.sum(~gdobj) > 0:
+        msgs.warn("Removed objects near the slit edges")
+    #
     nobj = objl.size
-    if msgs._debug['trace_obj']:
-        debugger.set_trace()
-        #nobj = 1
     if nobj==1:
         msgs.info("Found {0:d} object".format(objl.size))
         msgs.info("Tracing {0:d} object".format(objl.size))
@@ -406,10 +418,13 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
     cval = np.zeros(nobj)
     allsfit = np.array([])
     allxfit = np.array([])
+    clip_image2 = sigma_clip(mask_sigframe, axis=0, sigma=4.)
     for o in range(nobj):
         xfit = np.arange(objl[o],objr[o]).reshape((1,-1))/(npix-1.0)
-        cent = np.ma.sum(mask_sigframe[:,objl[o]:objr[o]]*xfit, axis=1)
-        wght = np.ma.sum(mask_sigframe[:,objl[o]:objr[o]], axis=1)
+        #cent = np.ma.sum(mask_sigframe[:,objl[o]:objr[o]]*xfit, axis=1)
+        #wght = np.ma.sum(mask_sigframe[:,objl[o]:objr[o]], axis=1)
+        cent = np.ma.sum(clip_image2[:,objl[o]:objr[o]]*xfit, axis=1)
+        wght = np.ma.sum(clip_image2[:,objl[o]:objr[o]], axis=1)
         cent /= wght
         centfit = cent.filled(maskval)
         specfit = np.linspace(-1.0, 1.0, sciframe.shape[0])
@@ -491,6 +506,13 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2.0,
         rec_img[np.where(idxarr==1)] = rec_bg_arr
         rec_bg_img[:,:,o] = rec_img.copy()
         #arutils.ds9plot(rec_img)
+    # Check object traces in ginga
+    if msgs._debug['trace_obj']:
+        from pypit import ginga
+        viewer, ch = ginga.show_image(sciframe)
+        for ii in range(nobj):
+            ginga.show_trace(viewer, ch, traces[:,ii], '{:d}'.format(ii), clear=(ii==0))
+        debugger.set_trace()
     # Save the quality control
     if doqa and (not msgs._debug['no_qa']):
         arqa.obj_trace_qa(slf, sciframe, trobjl, trobjr, root="object_trace", normalize=False)

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -19,7 +19,6 @@ from collections import Counter
 msgs = armsgs.get_logger()
 
 from pypit import ardebug as debugger
-from xastropy.xutils import xdebug as xdb
 
 
 def assign_slits(binarr, edgearr, ednum=100000, lor=-1):

--- a/pypit/scripts/run_pypit.py
+++ b/pypit/scripts/run_pypit.py
@@ -24,10 +24,10 @@ debug = ardebug.init()
 #debug['sky_sub'] = True
 #debug['trace'] = True
 #debug['obj_profile'] = True
-#debug['trace_obj'] = True
+debug['trace_obj'] = True
 #debug['tilts'] = True
 #debug['flexure'] = True
-#debug['no_qa'] = True
+debug['no_qa'] = True
 
 from pypit.armsgs import Messages as Initmsg
 initmsgs = Initmsg(None, debug, 1)

--- a/pypit/scripts/run_pypit.py
+++ b/pypit/scripts/run_pypit.py
@@ -24,10 +24,10 @@ debug = ardebug.init()
 #debug['sky_sub'] = True
 #debug['trace'] = True
 #debug['obj_profile'] = True
-debug['trace_obj'] = True
+#debug['trace_obj'] = True
 #debug['tilts'] = True
 #debug['flexure'] = True
-debug['no_qa'] = True
+#debug['no_qa'] = True
 
 from pypit.armsgs import Messages as Initmsg
 initmsgs = Initmsg(None, debug, 1)


### PR DESCRIPTION
Primary advance here is to reduce the effect of CRs on
object identification.  This is performed by sigma_clipping
the rectified image in artrace.trace_object() prior to smashing
it into trcprof.

The change may make it less likely to detect a bright emission
line source, but those were going to be challenging anyhow.
We can make the sigma_clipping a user-option instead.

Also removes objects identified within 3% of the slit edge, by default.

Tested extensively on LRISr data.  False positives are reduced although
not entirely eliminated.

New docs
No new tests