### PR TITLE
Hotfix

### DIFF
--- a/pypit/arsave.py
+++ b/pypit/arsave.py
@@ -13,6 +13,7 @@ from astropy.table import Table
 import h5py
 
 from pypit import armsgs
+from pypit import arutils
 from pypit import arparse as settings
 
 from pypit import ardebug as debugger

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -1975,7 +1975,8 @@ def multislit_tilt(slf, msarc, det, maskval=-999999.9):
     extrapord : ndarray
       A boolean mask indicating if an order was extrapolated (True = extrapolated)
     """
-    arccen, maskslit, satmask = get_censpec(slf, msarc, det, gen_satmask=True)
+    arccen, maskslit = get_censpec(slf, msarc, det, gen_satmask=False)
+    satmask = np.zeros_like(slf._pixcen)
     # If the user sets no tilts, return here
     if settings.argflag['trace']['slits']['tilts']['method'].lower() == "zero":
         # Assuming there is no spectral tilt

--- a/pypit/arutils.py
+++ b/pypit/arutils.py
@@ -91,8 +91,9 @@ def bspline_fit(x,y,order=3,knots=None,everyn=20,xmin=None,xmax=None,w=None,bksp
             nbkpts = max(int(xrnge/bkspace) + 1,2)
             tempbkspace = xrnge/(nbkpts-1)
             knots = np.arange(1,nbkpts-1)*tempbkspace + startx
-        elif everyn is not None: # A knot every good N pixels
-            idx_knots = np.arange(10, ngd-10, everyn)
+        elif everyn is not None:
+            # A knot every good N pixels
+            idx_knots = np.arange(everyn//2, ngd-everyn//2, everyn)
             knots = x[gd[idx_knots]]
         else:
             msgs.error("No method specified to generate knots")
@@ -101,8 +102,10 @@ def bspline_fit(x,y,order=3,knots=None,everyn=20,xmin=None,xmax=None,w=None,bksp
     # Generate spline
     try:
         tck = interpolate.splrep(x[gd], y[gd], w=weights, k=order, xb=xmin, xe=xmax, t=knots, task=task)
-    except ValueError: # Knot problem
+    except ValueError:
+        # Knot problem
         msgs.warn("Problem in the bspline knot")
+        debugger.set_trace()
     return tck
 
 


### PR DESCRIPTION
Fixes minor bugs in PR #205, and addresses bugs reported in Issue #208.

Note, there are still bugs in the development suite for ISIS blue, LRISb (400, not 600):

```
[INFO]    :: arflux.py 424 generate_sensfunc() - Masking edges
[WARNING] :: arflux.py 430 generate_sensfunc() - Should pull resolution from arc line analysis
[INFO]    :: arflux.py 434 generate_sensfunc() - Masking Balmer
[INFO]    :: arflux.py 441 generate_sensfunc() - Masking Telluric
[WARNING] :: arutils.py 107 bspline_fit() - Problem in the bspline knot
```

and for Kast red:

```
[ERROR]   :: arload.py 163 load_headers() - The headers could not be read from the input data files.
             Please check that the settings file matches the data.
```

* I've figured out that the first bug can be fixed by changing the knot spacing (i.e. the variable `everyn`). Before changing this default value - I wanted to check why this hasn't been noticed previously? Maybe there have been some other recent developments affecting the flux calibration routine?

* Kast red fails because it can't identify bias files (some of the lamps are turned on during the bias frames). So, this needs to be corrected in the pypit file in the development suite (i.e. not in this PR). Again, I haven't seen this before, but I'm surprised that it hasn't been noticed. The solution here is to manually assign these donkey frames as bias frames  :-)