### PR TITLE
Detect lines fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@
 * Added support for TNG+Dolores long slit spectrograph
 * Started removing cython code
 * Update line detection algorithm
+* Updated flexure documentation
 
 0.7 (2017-02-07)
 ----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,8 @@
 * Enable archiving/loading sensitivity function
 * Add new cosmic ray algorithms for coadding (especially pairs of spectra)
 * Added support for TNG+Dolores long slit spectrograph
-
+* Started removing cython code
+* Update line detection algorithm
 
 0.7 (2017-02-07)
 ----------------

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -88,7 +88,7 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     #####
     # New algorithm for arc line detection
     #pixels=[]
-    siglev = 6.0*settings.argflag['arc']['calibrate']['detection']
+    siglev = settings.argflag['arc']['calibrate']['detection']
     bpfit = 5  # order of the polynomial used to fit the background 'continuum'
     fitp = settings.argflag['arc']['calibrate']['nfitpix']
     if len(censpec.shape) == 3: detns = censpec[:, 0].flatten()
@@ -105,7 +105,7 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
         ct = np.polyfit(xfit, yfit, bpfit)
         yrng = np.polyval(ct, xrng)
         sigmed = 1.4826*np.median(np.abs(detns[w]-yrng[w]))
-        w = np.where(detns > yrng+1.0*sigmed)
+        w = np.where(detns > yrng + siglev*sigmed)
         mask[w] = 1
         if mskcnt == np.sum(mask):
             break  # No new values have been included in the mask

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -120,9 +120,9 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     # Find all significant detections
     # The last argument is the overall minimum significance level of an arc line detection and the second
     # last argument is the level required by an individual pixel before the neighbourhood of this pixel is searched.
-    tpixt, num = arcyarc.detections_sigma(yprep, yerr, np.zeros(censpec.shape[0], dtype=np.int), siglev/2.0, siglev)
-    pixt = arcyarc.remove_similar(tpixt, num)
-    pixt = pixt[np.where(pixt != -1)].astype(np.int)
+    pixt = np.where((yprep/yerr>0.0) & (yprep>np.roll(yprep,1)) & (yprep>=np.roll(yprep,-1))
+                                      & (np.roll(yprep,1)>np.roll(yprep,2)) & (np.roll(yprep,-1)>np.roll(yprep,-2))
+                                      & (np.roll(yprep,2)>np.roll(yprep,3)) & (np.roll(yprep,-2)>np.roll(yprep,-3)))[0]
     tampl, tcent, twid, ngood = arcyarc.fit_arcorder(xrng, yprep, pixt, fitp)
     w = np.where((~np.isnan(twid)) & (twid > 0.0) & (twid < 10.0/2.35) & (tcent > 0.0) & (tcent < xrng[-1]))
     # Check the results

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -96,7 +96,8 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     xrng = np.arange(float(detns.size))
     yrng = np.zeros(detns.size)
     mask = np.zeros(detns.size, dtype=np.int)
-    mskcnt = 0
+    mask[np.where(detns < 0.0)] = 1.0
+    mskcnt = np.sum(mask)
     while True:
         w = np.where(mask == 0)
         xfit = xrng[w]
@@ -104,7 +105,7 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
         ct = np.polyfit(xfit, yfit, bpfit)
         yrng = np.polyval(ct, xrng)
         sigmed = 1.4826*np.median(np.abs(detns[w]-yrng[w]))
-        w = np.where(detns > yrng+1.5*sigmed)
+        w = np.where(detns > yrng+1.0*sigmed)
         mask[w] = 1
         if mskcnt == np.sum(mask):
             break  # No new values have been included in the mask
@@ -120,9 +121,10 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     # Find all significant detections
     # The last argument is the overall minimum significance level of an arc line detection and the second
     # last argument is the level required by an individual pixel before the neighbourhood of this pixel is searched.
-    pixt = np.where((yprep/yerr>0.0) & (yprep>np.roll(yprep,1)) & (yprep>=np.roll(yprep,-1))
-                                      & (np.roll(yprep,1)>np.roll(yprep,2)) & (np.roll(yprep,-1)>np.roll(yprep,-2))
-                                      & (np.roll(yprep,2)>np.roll(yprep,3)) & (np.roll(yprep,-2)>np.roll(yprep,-3)))[0]
+    pixt = np.where((yprep/yerr > 0.0) &
+                    (yprep > np.roll(yprep, 1)) & (yprep >= np.roll(yprep, -1)) &
+                    (np.roll(yprep, 1) > np.roll(yprep, 2)) & (np.roll(yprep, -1) > np.roll(yprep, -2)) &
+                    (np.roll(yprep, 2) > np.roll(yprep, 3)) & (np.roll(yprep, -2) > np.roll(yprep, -3)))[0]
     tampl, tcent, twid, ngood = arcyarc.fit_arcorder(xrng, yprep, pixt, fitp)
     w = np.where((~np.isnan(twid)) & (twid > 0.0) & (twid < 10.0/2.35) & (tcent > 0.0) & (tcent < xrng[-1]))
     # Check the results

--- a/pypit/tests/test_arflux.py
+++ b/pypit/tests/test_arflux.py
@@ -7,6 +7,11 @@ import sys
 import os, pdb
 import pytest
 
+try:
+    tsterror = FileExistsError
+except NameError:
+    FileExistsError = OSError
+
 from astropy import units as u
 from astropy.units import Quantity
 


### PR DESCRIPTION
This PR makes improvements to the previous detect_lines algorithm, and removes some cython code. The development suite passes. The test suite does not pass. I have fixed one of the bugs in the test suite. The remaining errors are not related to this PR (the problem is with `collate` in linetools, and the `test_npeaks` function in `test_objfind.py`).

Note, you will need to reinstall your PYPIT installation once this PR is merged to the master branch.