### PR TITLE
removing cython

### DIFF
--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -22,6 +22,9 @@ from pypit import ardebug as debugger
 # Logging
 msgs = armsgs.get_logger()
 
+#KBW TESTING
+import time
+
 
 def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0):
     """ Generate a frame containing the background sky spectrum
@@ -1710,7 +1713,34 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
     filt  = ndimage.sobel(sciframe, axis=1, mode='constant')
     filty = ndimage.sobel(filt/np.sqrt(np.abs(sciframe)), axis=0, mode='constant')
     filty[np.where(np.isnan(filty))]=0.0
-    sigimg  = arcyproc.cr_screen(filty,0.0)
+
+#    t = time.clock()
+#    sigimg  = arcyproc.cr_screen(filty,0.0)
+#    print('Old cr_screen: {0} seconds'.format(time.clock() - t))
+#
+#    t = time.clock()
+#    new_sigimg  = new_cr_screen(filty,0.0)
+#    print('New cr_screen: {0} seconds'.format(time.clock() - t))
+    sigimg  = new_cr_screen(filty)
+
+#    print(sigimg.shape)
+#    print(new_sigimg.shape)
+#    print(np.ma.mean(np.ma.log10(sigimg)))
+#    print(np.ma.mean(np.ma.log10(new_sigimg)))
+#    print(np.ma.mean(np.ma.log10(sigimg)-np.ma.log10(new_sigimg)))
+#
+#    plt.imshow(np.ma.log10(sigimg), origin='lower', interpolation='nearest', aspect='auto')
+#    plt.colorbar()
+#    plt.show()
+#
+#    plt.imshow(np.ma.log10(new_sigimg), origin='lower', interpolation='nearest', aspect='auto')
+#    plt.colorbar()
+#    plt.show()
+#
+#    plt.imshow(np.ma.log10(new_sigimg)-np.ma.log10(sigimg), origin='lower', interpolation='nearest', aspect='auto')
+#    plt.colorbar()
+#    plt.show()
+
     sigsmth = ndimage.filters.gaussian_filter(sigimg,1.5)
     sigsmth[np.where(np.isnan(sigsmth))]=0.0
     sigmask = np.cast['bool'](np.zeros(sciframe.shape))
@@ -1719,6 +1749,50 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
     msgs.info("Growing cosmic ray mask by 1 pixel")
     crmask = arcyutils.grow_masked(crmask.astype(np.float), grow, 1.0)
     return crmask
+
+
+def new_cr_screen(a, mask_value=0.0, spatial_axis=1):
+    r"""
+    Calculate the significance of pixel deviations from the median along
+    the spatial direction.
+
+    No type checking is performed of the input array; however, the
+    function assumes floating point values.
+
+    Args:
+        a (numpy.ndarray): Input 2D array
+        mask_value (float): (**Optional**) Values to ignore during the
+            calculation of the median.  Default is 0.0.
+        spatial_axis (int): (**Optional**) Axis along which to calculate
+            the median.  Default is 1.
+
+    Returns:
+        numpy.ndarray: Returns a map of :math:`|\Delta_{i,j}|/\sigma_j`,
+        where :math:`\Delta_{i,j}` is the difference between the pixel
+        value and the median along axis :math:`i` and :math:`\sigma_j`
+        is robustly determined using the median absolute deviation,
+        :math:`sigma_j = 1.4826 MAD`.
+
+    Raises:
+        ValueError: Raised if the input array is not two dimensional or
+            if the selected axis is neither 0 nor 1.
+    """
+    # Check input
+    if len(a.shape) != 2:
+        raise ValueError('Input array must be two-dimensional.')
+    if spatial_axis not in [0,1]:
+        raise ValueError('Spatial axis must be 0 or 1.')
+
+    # Mask the pixels equal to mask value: should use np.isclose()
+    _a = np.ma.MaskedArray(a, mask=(a==mask_value))
+    # Get the median along the spatial axis
+    meda = np.ma.median(_a, axis=spatial_axis)
+    # Get a robust measure of the standard deviation using the median
+    # absolute deviation; 1.4826 factor is the ratio of sigma/MAD
+    d = np.absolute(_a - meda[:,None])
+    mada = 1.4826*np.ma.median(d, axis=spatial_axis)
+    # Return the ratio of the difference to the standard deviation
+    return np.ma.divide(d, mada[:,None]).filled(0.0)
 
 
 def gain_frame(slf, det):

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -1721,8 +1721,8 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
 #    t = time.clock()
 #    new_sigimg  = new_cr_screen(filty,0.0)
 #    print('New cr_screen: {0} seconds'.format(time.clock() - t))
-    sigimg  = arcyproc.cr_screen(filty,0.0)
-#    sigimg  = new_cr_screen(filty)
+#    sigimg  = arcyproc.cr_screen(filty,0.0)
+    sigimg  = new_cr_screen(filty)
 
 #    print(sigimg.shape)
 #    print(new_sigimg.shape)

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -1721,7 +1721,8 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
 #    t = time.clock()
 #    new_sigimg  = new_cr_screen(filty,0.0)
 #    print('New cr_screen: {0} seconds'.format(time.clock() - t))
-    sigimg  = new_cr_screen(filty)
+    sigimg  = arcyproc.cr_screen(filty,0.0)
+#    sigimg  = new_cr_screen(filty)
 
 #    print(sigimg.shape)
 #    print(new_sigimg.shape)

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -571,10 +571,10 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
     elif settings.argflag['trace']['object']['find'] == 'standard':
 #        print('calling find_objects')
 #        t = time.clock()
-#        objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+        objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
 #        print('Old find_objects: {0} seconds'.format(time.clock() - t))
 #        t = time.clock()
-        objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
+#        objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
 #        print('New find_objects: {0} seconds'.format(time.clock() - t))
     else:
         msgs.error("Bad object identification algorithm!!")
@@ -1174,11 +1174,10 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
 
 #        print('calling ignore_orders')
 #        t = time.clock()
-#        lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
+        lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
 #        print('Old ignore_orders: {0} seconds'.format(time.clock() - t))
 #        t = time.clock()
-        lnc, lxc, rnc, rxc, ldarr, rdarr = new_ignore_orders(edgearr, fracpix, lmin, lmax, rmin,
-                                                             rmax)
+#        lnc, lxc, rnc, rxc, ldarr, rdarr = new_ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
 #        print('New ignore_orders: {0} seconds'.format(time.clock() - t))
 
         lmin += lnc

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -1,5 +1,6 @@
 from __future__ import (print_function, absolute_import, division, unicode_literals)
 
+import time
 import numpy as np
 import copy
 from pypit import arqa
@@ -121,6 +122,7 @@ def assign_slits(binarr, edgearr, ednum=100000, lor=-1):
                 # After pruning, there are no more peaks
                 break
             pks = wpk+2  # Shifted by 2 because of the peak finding algorithm above
+#            print('calling find_peak_limits')
             pedges = arcytrace.find_peak_limits(smedgehist, pks)
             if np.all(pedges[:, 1]-pedges[:, 0] == 0):
                 # Remaining peaks have no width
@@ -289,6 +291,7 @@ def expand_slits(slf, mstrace, det, ordcen, extord):
     # Calculate the pixel locations of th eorder edges
     pixcen = phys_to_pix(ordcen, slf._pixlocn[det - 1], 1)
     msgs.info("Expanding slit traces to slit edges")
+    exit()
     mordwid, pordwid = arcytrace.expand_slits(mstrace, pixcen, extord.astype(np.int))
     # Fit a function for the difference between left edge and the centre trace
     ldiff_coeff, ldiff_fit = arutils.polyfitter2d(mordwid, mask=-1,
@@ -567,7 +570,13 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
         trcprof2 = np.mean(rec_sciframe, axis=0)
         objl, objr, bckl, bckr = find_obj_minima(trcprof2, triml=triml, trimr=trimr, nsmooth=nsmooth)
     elif settings.argflag['trace']['object']['find'] == 'standard':
-        objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+#        print('calling find_objects')
+#        t = time.clock()
+#        objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+#        print('Old find_objects: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
+        objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
+#        print('New find_objects: {0} seconds'.format(time.clock() - t))
     else:
         msgs.error("Bad object identification algorithm!!")
     if msgs._debug['trace_obj']:
@@ -696,6 +705,109 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
                           root="object_trace", normalize=False)
     # Return
     return tracedict
+
+
+def new_ignore_orders(edgdet, fracpix, lmin, lmax, rmin, rmax):
+
+    sz_x = edgdet.shape[0]
+    sz_y = edgdet.shape[1]
+
+    larr = np.zeros((2,lmax-lmin+1), dtype=int)
+    rarr = np.zeros((2,rmax-rmin+1), dtype=int)
+
+    larr[0,:] = sz_x
+    rarr[0,:] = sz_x
+
+    # TODO: Can I remove the loop?
+    for x in range(sz_x):
+        indx = edgdet[x,:] < 0
+        if np.any(indx):
+            larr[0,-edgdet[x,indx]-lmin] = np.clip(larr[0,-edgdet[x,indx]-lmin], None, x)
+            larr[1,-edgdet[x,indx]-lmin] = np.clip(larr[1,-edgdet[x,indx]-lmin], x, None)
+        indx = edgdet[x,:] > 0
+        if np.any(indx):
+            rarr[0,edgdet[x,indx]-rmin] = np.clip(rarr[0,edgdet[x,indx]-rmin], None, x)
+            rarr[1,edgdet[x,indx]-rmin] = np.clip(rarr[1,edgdet[x,indx]-rmin], x, None)
+
+    # Go through the array once more to remove pixels that do not cover fracpix
+    lt_zero = (edgdet < 0)
+    if np.any(lt_zero):
+        indx = larr[1,-edgdet[lt_zero]-lmin] - larr[0,-edgdet[lt_zero]-lmin] < fracpix
+        edgdet[lt_zero][indx] = 0
+
+    gt_zero = edgdet > 0
+    if np.any(gt_zero):
+        indx = rarr[1,edgdet[gt_zero]-rmin] - rarr[0,edgdet[gt_zero]-rmin] < fracpix
+        edgdet[gt_zero][indx] = 0
+
+    # Check if lmin, lmax, rmin, and rmax need to be changed
+    lindx = np.arange(larr.shape[1])[larr[1,:]-larr[0,:] > fracpix]
+    lnc = lindx[0]
+    lxc = lindx[-1]-lmax+lmin
+
+    rindx = np.arange(rarr.shape[1])[rarr[1,:]-rarr[0,:] > fracpix]
+    rnc = rindx[0]
+    rxc = rindx[-1]-rmax+rmin
+
+    return lnc, lxc, rnc, rxc, larr, rarr
+
+
+def new_find_objects(profile, bgreg, stddev):
+    """
+    Find significantly detected objects in the profile array
+    For all objects found, the background regions will be defined.
+    """
+    # Input profile must be a vector
+    if len(profile.shape) != 1:
+        raise ValueError('Input profile array must be 1D.')
+    # Get the length of the array
+    sz_x = profile.size
+    # Copy it to a masked array for processing
+    # TODO: Assumes input is NOT a masked array
+    _profile = np.ma.MaskedArray(profile.copy())
+
+    # Peaks are found as having flux at > 5 sigma and background is
+    # where the flux is not greater than 3 sigma
+    gt_5_sigma = profile > 5*stddev
+    not_gt_3_sigma = np.invert(profile > 3*stddev)
+
+    # Define the object centroids array
+    objl = np.zeros(sz_x, dtype=int)
+    objr = np.zeros(sz_x, dtype=int)
+    has_obj = np.zeros(sz_x, dtype=bool)
+
+    obj = 0
+    while np.any(gt_5_sigma & np.invert(_profile.mask)):
+        # Find next maximum flux point
+        imax = np.ma.argmax(_profile)
+        maxv = _profile[imax]
+        # Find the valid source pixels around the peak
+        f = np.arange(sz_x)[np.roll(not_gt_3_sigma, -imax)]
+        objl[obj] = imax-sz_x+f[-1]
+        objr[obj] = f[0]+imax
+        # Mask source pixels and increment for next iteration
+        has_obj[objl[obj]:objr[obj]+1] = True
+        _profile[objl[obj]:objr[obj]+1] = np.ma.masked
+        obj += 1
+
+    # The background is the region away from sources up to the provided
+    # region size.  Starting pixel for the left limit...
+    s = objl[:obj]-bgreg
+    s[s < 0] = 0
+    # ... and ending pixel for the right limit.
+    e = objr[:obj]+1+bgreg
+    e[e > sz_x] = sz_x
+    # Flag the possible background regions
+    bgl = np.zeros((sz_x,obj), dtype=bool)
+    bgr = np.zeros((sz_x,obj), dtype=bool)
+    for i in range(obj):
+        bgl[s[i]:objl[i]] = True
+        bgr[objl[i]+1:e[i]] = True
+
+    # Return source region limits and background regions that do not
+    # have sources
+    return objl[:obj], objr[:obj], (bgl & np.invert(has_obj)[:,None]).astype(int), \
+                    (bgr & np.invert(has_obj)[:,None]).astype(int)
 
 
 def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
@@ -907,6 +1019,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
         assign_slits(binarr, edgearrcp, lor=+1)
     if settings.argflag['trace']['slits']['maxgap'] is not None:
         vals = np.sort(np.unique(edgearrcp[np.where(edgearrcp != 0)]))
+#        print('calling close_edges')
         hasedge = arcytrace.close_edges(edgearrcp, vals, int(settings.argflag['trace']['slits']['maxgap']))
         # Find all duplicate edges
         edgedup = vals[np.where(hasedge == 1)]
@@ -991,10 +1104,12 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
                 wvla = np.unique(edgearr[wdup][wdda])
                 wvlb = np.unique(edgearr[wdup][wddb])
                 # Now generate the dual edge
+#                print('calling dual_edge')
                 arcytrace.dual_edge(edgearr, edgearrcp, wdup[0], wdup[1], wvla, wvlb, shadj,
                                     int(settings.argflag['trace']['slits']['maxgap']), edgedup[jj])
         # Now introduce new edge locations
         vals = np.sort(np.unique(edgearrcp[np.where(edgearrcp != 0)]))
+#        print('calling close_slits')
         edgearrcp = arcytrace.close_slits(binarr, edgearrcp, vals, int(settings.argflag['trace']['slits']['maxgap']))
     # Update edgearr
     edgearr = edgearrcp.copy()
@@ -1057,7 +1172,16 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
         #msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0]*binby)))
         msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0])))
         fracpix = int(settings.argflag['trace']['slits']['fracignore']*edgearr.shape[0])
-        lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
+
+#        print('calling ignore_orders')
+#        t = time.clock()
+#        lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
+#        print('Old ignore_orders: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
+        lnc, lxc, rnc, rxc, ldarr, rdarr = new_ignore_orders(edgearr, fracpix, lmin, lmax, rmin,
+                                                             rmax)
+#        print('New ignore_orders: {0} seconds'.format(time.clock() - t))
+
         lmin += lnc
         rmin += rnc
         lmax -= lxc
@@ -1200,6 +1324,7 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
     if mnvalp > mnvalm:
         lvp = (arutils.func_val(lcoeff[:, lval+1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)
+#        print('calling find_between')
         edgbtwn = arcytrace.find_between(edgearr, lv, lvp, 1)
         # edgbtwn is a 3 element array that determines what is between two adjacent left edges
         # edgbtwn[0] is the next right order along, from left order lval
@@ -1537,6 +1662,7 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         lopos = phys_to_pix(extfit[:,-i]-srchz, locations, 1)  # The pixel indices for the bottom of the search window
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,-i])))
         diffarr = np.round(extrap_diff[:,-i]).astype(np.int)
+#        print('calling find_shift')
         shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
         relshift = np.mean(shift+extrap_diff[:,-i]/2-srchz)
         if shift == -1:
@@ -1564,6 +1690,7 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         lopos = phys_to_pix(extfit[:,i-1]-srchz, locations, 1)
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,i-1])))
         diffarr = np.round(extrap_diff[:,i-1]).astype(np.int)
+#        print('calling find_shift')
         shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
         relshift = np.mean(shift+extrap_diff[:,i-1]/2-srchz)
         if shift == -1:
@@ -2510,6 +2637,7 @@ def get_censpec(slf, frame, det, gen_satmask=False):
     if gen_satmask:
         msgs.info("Generating a mask of arc line saturation streaks")
         satmask = arcyarc.saturation_mask(frame, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+#        print('calling order saturation')
         satsnd = arcyarc.order_saturation(satmask, (ordcen+0.5).astype(np.int), (ordwid+0.5).astype(np.int))
     # Extract a rough spectrum of the arc in each slit
     msgs.info("Extracting an approximate arc spectrum at the centre of each slit")

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -291,7 +291,6 @@ def expand_slits(slf, mstrace, det, ordcen, extord):
     # Calculate the pixel locations of th eorder edges
     pixcen = phys_to_pix(ordcen, slf._pixlocn[det - 1], 1)
     msgs.info("Expanding slit traces to slit edges")
-    exit()
     mordwid, pordwid = arcytrace.expand_slits(mstrace, pixcen, extord.astype(np.int))
     # Fit a function for the difference between left edge and the centre trace
     ldiff_coeff, ldiff_fit = arutils.polyfitter2d(mordwid, mask=-1,
@@ -801,8 +800,8 @@ def new_find_objects(profile, bgreg, stddev):
     bgl = np.zeros((sz_x,obj), dtype=bool)
     bgr = np.zeros((sz_x,obj), dtype=bool)
     for i in range(obj):
-        bgl[s[i]:objl[i]] = True
-        bgr[objl[i]+1:e[i]] = True
+        bgl[s[i]:objl[i],i] = True
+        bgr[objl[i]+1:e[i],i] = True
 
     # Return source region limits and background regions that do not
     # have sources


### PR DESCRIPTION
This removes a few cython functions:

- removed dependency on pypit/arcyproc.pyx cr_screen, added new_cr_screen function to pypit/arproc.py
- removed dependency on pypit/arcytrace.pyx ignore_orders, added new_ignore_orders to pypit/artrace.py
- removed dependency on pypit/arcytrace.pyx find_objects, added new_find_objects to pypit/artrace.py

Codes passes 

python3 pypit_tests all

in PYPIT-development-suite.  Python 2 not tested (but should pass I think).
