### PR TITLE
Python replacements for most cython code

### DIFF
--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -77,23 +77,23 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     if MK_SATMASK:
         ordwid = 0.5*np.abs(slf._lordloc[det-1] - slf._rordloc[det-1])
         msgs.info("Generating a mask of arc line saturation streaks")
-        print('calling saturation_mask')
-        t = time.clock()
-        _satmask = arcyarc.saturation_mask(msarc, slf._nonlinear[det-1])
-        print('Old saturation_mask: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling saturation_mask')
+#        t = time.clock()
+#        _satmask = arcyarc.saturation_mask(msarc, slf._nonlinear[det-1])
+#        print('Old saturation_mask: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         satmask = new_saturation_mask(msarc, slf._nonlinear[det-1])
-        print('New saturation_mask: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_satmask != satmask) == 0, 'Difference between old and new saturation_mask'
+#        print('New saturation_mask: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_satmask != satmask) == 0, 'Difference between old and new saturation_mask'
 
-        print('calling order_saturation')
-        t = time.clock()
-        _satsnd = arcyarc.order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int))
-        print('Old order_saturation: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling order_saturation')
+#        t = time.clock()
+#        _satsnd = arcyarc.order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int))
+#        print('Old order_saturation: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         satsnd = new_order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int))
-        print('New order_saturation: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_satsnd != satsnd) == 0, 'Difference between old and new order_saturation'
+#        print('New order_saturation: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_satsnd != satsnd) == 0, 'Difference between old and new order_saturation'
     else:
         satsnd = np.zeros_like(ordcen)
     # Detect the location of the arc lines

--- a/pypit/ararc.py
+++ b/pypit/ararc.py
@@ -10,6 +10,7 @@ from pypit import ararclines
 from pypit import arqa
 from matplotlib import pyplot as plt
 import os
+import time
 
 from pypit import ardebug as debugger
 
@@ -76,8 +77,23 @@ def detect_lines(slf, det, msarc, censpec=None, MK_SATMASK=False):
     if MK_SATMASK:
         ordwid = 0.5*np.abs(slf._lordloc[det-1] - slf._rordloc[det-1])
         msgs.info("Generating a mask of arc line saturation streaks")
-        satmask = arcyarc.saturation_mask(msarc, slf._nonlinear[det-1])
-        satsnd = arcyarc.order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int))
+        print('calling saturation_mask')
+        t = time.clock()
+        _satmask = arcyarc.saturation_mask(msarc, slf._nonlinear[det-1])
+        print('Old saturation_mask: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        satmask = new_saturation_mask(msarc, slf._nonlinear[det-1])
+        print('New saturation_mask: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_satmask != satmask) == 0, 'Difference between old and new saturation_mask'
+
+        print('calling order_saturation')
+        t = time.clock()
+        _satsnd = arcyarc.order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int))
+        print('Old order_saturation: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        satsnd = new_order_saturation(satmask, ordcen, (ordwid+0.5).astype(np.int))
+        print('New order_saturation: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_satsnd != satsnd) == 0, 'Difference between old and new order_saturation'
     else:
         satsnd = np.zeros_like(ordcen)
     # Detect the location of the arc lines
@@ -576,3 +592,72 @@ def calib_with_arclines(slf, det, get_poly=False, use_method="general"):
     arqa.arc_fit_qa(slf, final_fit)
     #
     return final_fit
+
+
+
+def new_order_saturation(satmask, ordcen, ordwid):
+
+    sz_y, sz_x = satmask.shape
+    sz_o = ordcen.shape[1]
+
+    xmin = ordcen - ordwid
+    xmax = ordcen + ordwid + 1
+    xmin[xmin < 0] = 0
+    xmax[xmax >= sz_x] = sz_x
+
+    ordsat = np.zeros((sz_y, sz_o), dtype=int)
+    for o in range(sz_o):
+        for y in range(sz_y):
+            ordsat[y,o] = (xmax[y,o] > xmin[y,o]) & np.any(satmask[y,xmin[y,o]:xmax[y,o]] == 1)
+
+    return ordsat
+
+
+def search_for_saturation_edge(a, x, y, sy, dx, satdown, satlevel, mask):
+    sx = dx
+    localx = a[x+sx,y+sy]
+    while True:
+        mask[x+sx,y+sy] = True
+        sx += dx
+        if x+sx > a.shape[0]-1 or x+sx < 0:
+            break
+        if a[x+sx,y+sy] >= localx/satdown and a[x+sx,y+sy]<satlevel:
+            break
+        localx = a[x+sx,y+sy]
+    return mask
+
+
+def determine_saturation_region(a, x, y, sy, dy, satdown, satlevel, mask):
+    localy = a[x,y+sy]
+    while True:
+        mask[x,y+sy] = True
+        mask = search_for_saturation_edge(a, x, y, sy, 1, satdown, satlevel, mask)
+        mask = search_for_saturation_edge(a, x, y, sy, -1, satdown, satlevel, mask)
+        
+        sy += dy
+        if y+sy > a.shape[1]-1 or y+sy < 0:
+            return mask
+        if a[x,y+sy] >= localy/satdown and a[x,y+sy] < satlevel:
+            return mask
+        localy = a[x,y+sy]
+    
+
+def new_saturation_mask(a, satlevel):
+   
+    mask = np.zeros(a.shape, dtype=bool)
+    a_is_saturated = a >= satlevel
+    if not np.any(a_is_saturated):
+        return mask.astype(int)
+
+    satdown = 1.001
+    sz_x, sz_y = a.shape
+
+    for y in range (0,sz_y):
+        for x in range(0,sz_x):
+            if a_is_saturated[x,y] and not mask[x,y]:
+                mask[x,y] = True
+                mask = determine_saturation_region(a, x, y, 0, 1, satdown, satlevel, mask)
+                mask = determine_saturation_region(a, x, y, -1, -1, satdown, satlevel, mask)
+
+    return mask.astype(int)
+

--- a/pypit/arcomb.py
+++ b/pypit/arcomb.py
@@ -1,15 +1,23 @@
 from __future__ import (print_function, absolute_import, division, unicode_literals)
 
+import time
 import numpy as np
 from pypit import armsgs
 from pypit import arparse as settings
+from matplotlib import pyplot as plt
 
 # Logging
 msgs = armsgs.get_logger()
 
-
 def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, printtype=None):
     """ Combine several frames
+
+    .. todo::
+        - I've just replaced the arcycomb calls, but this function
+          should probably be rewritten so that it makes better use of
+          np.ma.MaskedArray objects throughout.
+
+        - Some of the replacement code still needs to be tested!
 
     Parameters
     ----------
@@ -18,18 +26,23 @@ def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, pri
     det : int
       Detector index
     frametype : str
-      What is the type of frame being combining? (only used for screen printout)
+      What is the type of frame being combining? (only used for screen
+      printout)
     weights : str, or None (optional)
-      How should the frame combination by weighted (not currently implemented)
+      How should the frame combination by weighted (not currently
+      implemented)
     maskvalue : int (optional)
-      What should the masked values be set to (should be greater than the detector's saturation value -- Default = 1 + 2**20)
+      What should the masked values be set to (should be greater than
+      the detector's saturation value -- Default = 1 + 2**20)
     printtype : str (optional)
-      The frame type string that should be printed by armsgs. If None, frametype will be used
+      The frame type string that should be printed by armsgs. If None,
+      frametype will be used
     """
     from pypit import arcycomb
     dnum = settings.get_dnum(det)
     reject = settings.argflag[frametype]['combine']['reject']
     method = settings.argflag[frametype]['combine']['method']
+
     ###########
     # FIRST DO SOME CHECKS ON THE INPUT
     ###########
@@ -46,59 +59,111 @@ def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, pri
         return frames_arr[:, :, 0]
     else:
         msgs.info("Combining {0:d} {1:s} frames".format(num_frames, printtype))
-    # Check if the user has allowed the combination of long and short frames (e.g. different exposure times)
+
+    # Check if the user has allowed the combination of long and short
+    # frames (e.g. different exposure times)
     msgs.work("lscomb feature has not been included here yet...")
     # Check the user hasn't requested to reject more frames than available
     if reject['lowhigh'][0] > 0 and reject['lowhigh'][1] > 0 and \
         reject['lowhigh'][0] + reject['lowhigh'][1] >= num_frames:
-        msgs.error("You cannot reject more frames than is available with 'reject lowhigh'." + msgs.newline() +
-                   "There are {0:d} frames and reject lowhigh will reject {1:d} low and {2:d} high".format(num_frames, reject['lowhigh'][0], reject['lowhigh'][1]))
+        msgs.error('You cannot reject more frames than is available with \'reject lowhigh\'.'
+                   + msgs.newline() + 'There are {0:d} frames '.format(num_frames)
+                   + 'and reject lowhigh will reject {0:d} low '.format(reject['lowhigh'][0])
+                   + 'and {0:d} high'.format(reject['lowhigh'][1]))
+
+    saturation = settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear']
+
     # Check that some information on the frames was supplied
     if settings.spect is None:
-        msgs.error("When combining the {0:s} frames, spectrograph information".format(printtype)+msgs.newline()+"was not provided")
+        msgs.error('When combining the {0:s} frames, spectrograph information'.format(printtype)
+                   + msgs.newline() + 'was not provided.')
     # Calculate the values to be used if all frames are rejected in some pixels
     if reject['replace'] == 'min':
-        allrej_arr = arcycomb.minmax(frames_arr, 0)
+#        allrej_arr = arcycomb.minmax(frames_arr, 0)
+        allrej_arr = np.amin(frames_arr, axis=2)
     elif reject['replace'] == 'max':
-        allrej_arr = arcycomb.minmax(frames_arr, 1)
+#        allrej_arr = arcycomb.minmax(frames_arr, 1)
+        allrej_arr = np.amax(frames_arr, axis=2)
     elif reject['replace'] == 'mean':
-        allrej_arr = arcycomb.mean(frames_arr)
+#        allrej_arr = arcycomb.mean(frames_arr)
+        allrej_arr = np.mean(frames_arr, axis=2)
     elif reject['replace'] == 'median':
-        allrej_arr = arcycomb.median(frames_arr)
+#        allrej_arr = arcycomb.median(frames_arr)
+        allrej_arr = np.median(frames_arr, axis=2)
     elif reject['replace'] == 'weightmean':
         msgs.work("No weights are implemented yet")
-        allrej_arr = arcycomb.masked_weightmean(frames_arr, maskvalue)
+        print('calling masked_weightmean')
+        _allrej_arr = frames_arr.copy()
+        t = time.clock()
+        _allrej_arr = arcycomb.masked_weightmean(_allrej_arr, maskvalue)
+        print('Old masked_weightmean: {0} seconds'.format(time.clock() - t))
+        __allrej_arr = frames_arr.copy()
+        t = time.clock()
+        __allrej_arr = new_masked_weightmean(__allrej_arr, maskvalue)
+        print('New masked_weightmean: {0} seconds'.format(time.clock() - t))
+        print(__allrej_arr.shape)
+        assert np.sum(__allrej_arr != _allrej_arr) == 0, \
+                    'Difference between old and new masked_weightmean'
+        allrej_arr = __allrej_arr
+##        allrej_arr = arcycomb.masked_weightmean(frames_arr, maskvalue)
+#        allrej_arr = new_masked_weightmean(frames_arr, maskvalue)
     elif reject['replace'] == 'maxnonsat':
-        allrej_arr = arcycomb.maxnonsat(frames_arr, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+        print('calling maxnonsat')
+        _allrej_arr = frames_arr.copy()
+        t = time.clock()
+        _allrej_arr = arcycomb.maxnonsat(_allrej_arr, saturation)
+        print('Old maxnonsat: {0} seconds'.format(time.clock() - t))
+        __allrej_arr = frames_arr.copy()
+        t = time.clock()
+        __allrej_arr = new_maxnonsat(__allrej_arr, saturation)
+        print('New maxnonsat: {0} seconds'.format(time.clock() - t))
+#       Bug in arcycomb.maxnonsat ?
+#        assert np.sum(__allrej_arr != _allrej_arr) == 0, 'Difference between old and new maxnonsat'
+        allrej_arr = __allrej_arr
+##        allrej_arr = arcycomb.maxnonsat(frames_arr, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+#        allrej_arr = new_maxnonsat(frames_arr, saturation)
     else:
         msgs.error("You must specify what to do in case all pixels are rejected")
+
     ################
     # Saturated Pixels
     msgs.info("Finding saturated and non-linear pixels")
     if settings.argflag[frametype]['combine']['satpix'] == 'force':
-        # If a saturated pixel is in one of the frames, force them to all have saturated pixels
+        # If a saturated pixel is in one of the frames, force them to
+        # all have saturated pixels
 #		satw = np.zeros_like(frames_arr)
 #		satw[np.where(frames_arr > settings.spect['det']['saturation']*settings.spect['det']['nonlinear'])] = 1.0
 #		satw = np.any(satw,axis=2)
-        setsat = arcycomb.masked_limitget(frames_arr, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'], 2)
 #		del satw
+#        setsat = arcycomb.masked_limitget(frames_arr, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'], 2)
+        setsat = np.zeros_like(frames_arr)
+        setsat[frames_arr > saturation] = 1
     elif settings.argflag[frametype]['combine']['satpix'] == 'reject':
         # Ignore saturated pixels in frames if possible
-        frames_arr = arcycomb.masked_limitset(frames_arr, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'], 2, maskvalue)
+#        frames_arr = arcycomb.masked_limitset(frames_arr, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'], 2, maskvalue)
+        frames_arr[frames_arr > saturation] = maskvalue
     elif settings.argflag[frametype]['combine']['satpix'] == 'nothing':
-        # Don't do anything special for saturated pixels (Hopefully the user has specified how to deal with them below!)
+        # Don't do anything special for saturated pixels (Hopefully the
+        # user has specified how to deal with them below!)
         pass
     else:
-        msgs.error("Option '{0:s}' for dealing with saturated pixels was not recognised".format(settings.argflag[frametype]['combine']['satpix']))
+        msgs.error('Option \'{0}\' '.format(settings.argflag[frametype]['combine']['satpix'])
+                   + 'for dealing with saturated pixels was not recognised.')
     # Delete unecessary arrays
     # None!
     ################
     # Cosmic Rays
     if reject['cosmics'] > 0.0:
         msgs.info("Rejecting cosmic rays")  # Use a robust statistic
-        medarr = arcycomb.masked_median(frames_arr, maskvalue)
-        stdarr = 1.4826*arcycomb.masked_median(np.abs(frames_arr-medarr[:, :, np.newaxis]), maskvalue)
-        frames_arr = arcycomb.masked_limitsetarr(frames_arr, (medarr + reject['cosmics']*stdarr), 2, maskvalue)
+        masked_fa = np.ma.MaskedArray(frames_arr, mask=frames_arr==maskvalue)
+        medarr = np.ma.median(masked_fa, axis=2)
+        stdarr = 1.4826*np.ma.median(np.ma.absolute(masked_fa - medarr[:,:,None]), axis=2)
+        indx = (frames_arr != maskvalue) \
+                    & (frames_arr > (medarr.data + reject['cosmics']*stdarr.data)[:,:,None])
+        frames_arr[indx] = maskvalue
+#        medarr = arcycomb.masked_median(frames_arr, maskvalue)
+#        stdarr = 1.4826*arcycomb.masked_median(np.abs(frames_arr-medarr[:, :, np.newaxis]), maskvalue)
+#        frames_arr = arcycomb.masked_limitsetarr(frames_arr, (medarr + reject['cosmics']*stdarr), 2, maskvalue)
         # Delete unecessary arrays
         del medarr, stdarr
     else:
@@ -136,10 +201,19 @@ def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, pri
     # Deviant Pixels
     if reject['level'][0] > 0.0 or reject['level'][1] > 0.0:
         msgs.info("Rejecting deviant pixels")  # Use a robust statistic
-        medarr = arcycomb.masked_median(frames_arr, maskvalue)
-        stdarr = 1.4826*arcycomb.masked_median(np.abs(frames_arr-medarr[:, :, np.newaxis]), maskvalue)
-        frames_arr = arcycomb.masked_limitsetarr(frames_arr, (medarr - reject['level'][0]*stdarr), -2, maskvalue)
-        frames_arr = arcycomb.masked_limitsetarr(frames_arr, (medarr + reject['level'][1]*stdarr), 2, maskvalue)
+
+        masked_fa = np.ma.MaskedArray(frames_arr, mask=frames_arr==maskvalue)
+        medarr = np.ma.median(masked_fa, axis=2)
+        stdarr = 1.4826*np.ma.median(np.ma.absolute(masked_fa - medarr[:,:,None]), axis=2)
+        indx = (frames_arr != maskvalue) \
+                    & ( (frames_arr > (medarr.data + reject['cosmics']*stdarr.data)[:,:,None])
+                        | (frames_arr < (medarr.data - reject['cosmics']*stdarr.data)[:,:,None]))
+        frames_arr[indx] = maskvalue
+
+#        medarr = arcycomb.masked_median(frames_arr, maskvalue)
+#        stdarr = 1.4826*arcycomb.masked_median(np.abs(frames_arr-medarr[:, :, np.newaxis]), maskvalue)
+#        frames_arr = arcycomb.masked_limitsetarr(frames_arr, (medarr - reject['level'][0]*stdarr), -2, maskvalue)
+#        frames_arr = arcycomb.masked_limitsetarr(frames_arr, (medarr + reject['level'][1]*stdarr), 2, maskvalue)
         # Delete unecessary arrays
         del medarr, stdarr
     else:
@@ -148,17 +222,46 @@ def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, pri
     # Combine the arrays
     msgs.info("Combining frames with a {0:s} operation".format(method))
     if method == 'mean':
-        frames_arr = arcycomb.masked_mean(frames_arr, maskvalue)
+#        frames_arr = arcycomb.masked_mean(frames_arr, maskvalue)
+        frames_arr = np.ma.mean(np.ma.MaskedArray(frames_arr, mask=frames_arr==maskvalue), axis=2)
     elif method == 'median':
-        frames_arr = arcycomb.masked_median(frames_arr, maskvalue)
+#        frames_arr = arcycomb.masked_median(frames_arr, maskvalue)
+        frames_arr = np.ma.median(np.ma.MaskedArray(frames_arr, mask=frames_arr==maskvalue), axis=2)
     elif method == 'weightmean':
-        frames_arr = arcycomb.masked_weightmean(frames_arr, maskvalue)
+        print('calling masked_weightmean')
+        _frames_arr = frames_arr.copy()
+        t = time.clock()
+        _frames_arr = arcycomb.masked_weightmean(_frames_arr, maskvalue)
+        print('Old masked_weightmean: {0} seconds'.format(time.clock() - t))
+        __frames_arr = frames_arr.copy()
+        t = time.clock()
+        __frames_arr = new_masked_weightmean(__frames_arr, maskvalue)
+        print('New masked_weightmean: {0} seconds'.format(time.clock() - t))
+        print(__frames_arr.shape)
+
+        if np.sum(np.absolute(__frames_arr-_frames_arr) > 1e-10) != 0:
+            print(np.sum(np.absolute(__frames_arr-_frames_arr) > 1e-10))
+            plt.imshow(_frames_arr, origin='lower', interpolation='nearest', aspect='auto')
+            plt.show()
+            plt.imshow(__frames_arr, origin='lower', interpolation='nearest', aspect='auto')
+            plt.show()
+            plt.imshow(_frames_arr - __frames_arr, origin='lower', interpolation='nearest', aspect='auto')
+            plt.show()
+            plt.imshow(np.ma.divide(_frames_arr,__frames_arr) - 1, origin='lower', interpolation='nearest', aspect='auto')
+            plt.colorbar()
+            plt.show()
+                    
+        assert np.sum( np.absolute(__frames_arr-_frames_arr) > 1e-10 ) == 0, \
+                    'Difference between old and new masked_weightmean'
+        frames_arr = __frames_arr
     else:
         msgs.error("Combination type '{0:s}' is unknown".format(method))
     ##############
     # If any pixels are completely masked, apply user-specified function
     msgs.info("Replacing completely masked pixels with the {0:s} value of the input frames".format(reject['replace']))
-    frames_arr = arcycomb.masked_replace(frames_arr, allrej_arr, maskvalue)
+#    frames_arr = arcycomb.masked_replace(frames_arr, allrej_arr, maskvalue)
+    indx = frames_arr == maskvalue
+    frames_arr[indx] = allrej_arr[indx]
     # Delete unecessary arrays
     del allrej_arr
     ##############
@@ -172,3 +275,42 @@ def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, pri
     # Make sure the returned array is the correct type
     frames_arr = np.array(frames_arr, dtype=np.float)
     return frames_arr
+
+
+def new_masked_weightmean(a, maskvalue):
+    num = np.ma.MaskedArray(a.copy(), mask=(a==maskvalue))
+    num[np.invert(num.mask) & (num <= 1.0)] = 0.0
+    num = np.ma.sum(np.ma.sqrt(num)*num, axis=2)
+    den = np.ma.MaskedArray(a.copy(), mask=(a==maskvalue))
+    den[np.invert(den.mask) & (den <= 1.0)] = 1.0
+    den = np.ma.sum(np.sqrt(den), axis=2)
+    return np.ma.divide(num, den).filled(maskvalue)
+
+
+def new_maxnonsat(array, saturated):
+    """
+    sz_x, sz_y, nfr = array.shape
+    mmarr = np.zeros((sz_x,sz_y), dtype=float)
+    d = 0
+    for x in range(sz_x):
+        for y in range(sz_y):
+            # Sort the array
+            temp = 0.0
+            minv = saturated
+            for n in range(nfr):
+                if array[x,y,n] > temp and (BUG: temp) < saturated:
+                    temp = array[x,y,n]
+                if array[x,y,n] < minv:
+                    minv = array[x,y,n]
+            if temp == 0.0:
+                mmarr[x,y] = minv
+            else:
+                mmarr[x,y] = temp
+    return mmarr
+    """
+    minimum = np.amin(np.clip(array, None, saturated), axis=2)
+    _array = np.ma.MaskedArray(array, mask=np.invert((array > 0.0) & (array<saturated)))
+    maximum = np.ma.amax(_array, axis=2)
+    maximum[maximum.mask] = minimum[maximum.mask]
+    return maximum.data
+

--- a/pypit/arcomb.py
+++ b/pypit/arcomb.py
@@ -92,31 +92,31 @@ def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, pri
         allrej_arr = np.median(frames_arr, axis=2)
     elif reject['replace'] == 'weightmean':
         msgs.work("No weights are implemented yet")
-        print('calling masked_weightmean')
-        _allrej_arr = frames_arr.copy()
-        t = time.clock()
-        _allrej_arr = arcycomb.masked_weightmean(_allrej_arr, maskvalue)
-        print('Old masked_weightmean: {0} seconds'.format(time.clock() - t))
+#        print('calling masked_weightmean')
+#        _allrej_arr = frames_arr.copy()
+#        t = time.clock()
+#        _allrej_arr = arcycomb.masked_weightmean(_allrej_arr, maskvalue)
+#        print('Old masked_weightmean: {0} seconds'.format(time.clock() - t))
         __allrej_arr = frames_arr.copy()
-        t = time.clock()
+#        t = time.clock()
         __allrej_arr = new_masked_weightmean(__allrej_arr, maskvalue)
-        print('New masked_weightmean: {0} seconds'.format(time.clock() - t))
-        print(__allrej_arr.shape)
-        assert np.sum(__allrej_arr != _allrej_arr) == 0, \
-                    'Difference between old and new masked_weightmean'
+#        print('New masked_weightmean: {0} seconds'.format(time.clock() - t))
+#        print(__allrej_arr.shape)
+#        assert np.sum(__allrej_arr != _allrej_arr) == 0, \
+#                    'Difference between old and new masked_weightmean'
         allrej_arr = __allrej_arr
 ##        allrej_arr = arcycomb.masked_weightmean(frames_arr, maskvalue)
 #        allrej_arr = new_masked_weightmean(frames_arr, maskvalue)
     elif reject['replace'] == 'maxnonsat':
-        print('calling maxnonsat')
-        _allrej_arr = frames_arr.copy()
-        t = time.clock()
-        _allrej_arr = arcycomb.maxnonsat(_allrej_arr, saturation)
-        print('Old maxnonsat: {0} seconds'.format(time.clock() - t))
+#        print('calling maxnonsat')
+#        _allrej_arr = frames_arr.copy()
+#        t = time.clock()
+#        _allrej_arr = arcycomb.maxnonsat(_allrej_arr, saturation)
+#        print('Old maxnonsat: {0} seconds'.format(time.clock() - t))
         __allrej_arr = frames_arr.copy()
-        t = time.clock()
+#        t = time.clock()
         __allrej_arr = new_maxnonsat(__allrej_arr, saturation)
-        print('New maxnonsat: {0} seconds'.format(time.clock() - t))
+#        print('New maxnonsat: {0} seconds'.format(time.clock() - t))
 #       Bug in arcycomb.maxnonsat ?
 #        assert np.sum(__allrej_arr != _allrej_arr) == 0, 'Difference between old and new maxnonsat'
         allrej_arr = __allrej_arr
@@ -228,31 +228,31 @@ def comb_frames(frames_arr, det, frametype, weights=None, maskvalue=1048577, pri
 #        frames_arr = arcycomb.masked_median(frames_arr, maskvalue)
         frames_arr = np.ma.median(np.ma.MaskedArray(frames_arr, mask=frames_arr==maskvalue), axis=2)
     elif method == 'weightmean':
-        print('calling masked_weightmean')
-        _frames_arr = frames_arr.copy()
-        t = time.clock()
-        _frames_arr = arcycomb.masked_weightmean(_frames_arr, maskvalue)
-        print('Old masked_weightmean: {0} seconds'.format(time.clock() - t))
+#        print('calling masked_weightmean')
+#        _frames_arr = frames_arr.copy()
+#        t = time.clock()
+#        _frames_arr = arcycomb.masked_weightmean(_frames_arr, maskvalue)
+#        print('Old masked_weightmean: {0} seconds'.format(time.clock() - t))
         __frames_arr = frames_arr.copy()
-        t = time.clock()
+#        t = time.clock()
         __frames_arr = new_masked_weightmean(__frames_arr, maskvalue)
-        print('New masked_weightmean: {0} seconds'.format(time.clock() - t))
-        print(__frames_arr.shape)
-
-        if np.sum(np.absolute(__frames_arr-_frames_arr) > 1e-10) != 0:
-            print(np.sum(np.absolute(__frames_arr-_frames_arr) > 1e-10))
-            plt.imshow(_frames_arr, origin='lower', interpolation='nearest', aspect='auto')
-            plt.show()
-            plt.imshow(__frames_arr, origin='lower', interpolation='nearest', aspect='auto')
-            plt.show()
-            plt.imshow(_frames_arr - __frames_arr, origin='lower', interpolation='nearest', aspect='auto')
-            plt.show()
-            plt.imshow(np.ma.divide(_frames_arr,__frames_arr) - 1, origin='lower', interpolation='nearest', aspect='auto')
-            plt.colorbar()
-            plt.show()
-                    
-        assert np.sum( np.absolute(__frames_arr-_frames_arr) > 1e-10 ) == 0, \
-                    'Difference between old and new masked_weightmean'
+#        print('New masked_weightmean: {0} seconds'.format(time.clock() - t))
+#        print(__frames_arr.shape)
+#
+#        if np.sum(np.absolute(__frames_arr-_frames_arr) > 1e-10) != 0:
+#            print(np.sum(np.absolute(__frames_arr-_frames_arr) > 1e-10))
+#            plt.imshow(_frames_arr, origin='lower', interpolation='nearest', aspect='auto')
+#            plt.show()
+#            plt.imshow(__frames_arr, origin='lower', interpolation='nearest', aspect='auto')
+#            plt.show()
+#            plt.imshow(_frames_arr - __frames_arr, origin='lower', interpolation='nearest', aspect='auto')
+#            plt.show()
+#            plt.imshow(np.ma.divide(_frames_arr,__frames_arr) - 1, origin='lower', interpolation='nearest', aspect='auto')
+#            plt.colorbar()
+#            plt.show()
+#                    
+#        assert np.sum( np.absolute(__frames_arr-_frames_arr) > 1e-10 ) == 0, \
+#                    'Difference between old and new masked_weightmean'
         frames_arr = __frames_arr
     else:
         msgs.error("Combination type '{0:s}' is unknown".format(method))

--- a/pypit/arextract.py
+++ b/pypit/arextract.py
@@ -93,15 +93,15 @@ def boxcar(slf, det, specobjs, sciframe, varframe, skyframe, crmask, scitrace):
             mask_sci = np.ma.array(sciframe, mask=bg_mask, fill_value=0.)
             clip_image = sigma_clip(mask_sci, axis=1, sigma=3.)  # For the mask only
             # Fit
-            print('calling func2d_fit_val')
-            t = time.clock()
-            _bgframe = arcyutils.func2d_fit_val(bgfit, sciframe,
-                                                (~clip_image.mask)*bckreg*cr_mask, bgfitord)
-            print('Old func2d_fit_val: {0} seconds'.format(time.clock() - t))
-            t = time.clock()
+#            print('calling func2d_fit_val')
+#            t = time.clock()
+#            _bgframe = arcyutils.func2d_fit_val(bgfit, sciframe,
+#                                                (~clip_image.mask)*bckreg*cr_mask, bgfitord)
+#            print('Old func2d_fit_val: {0} seconds'.format(time.clock() - t))
+#            t = time.clock()
             bgframe = new_func2d_fit_val(sciframe, bgfitord, x=bgfit,
                                          w=(~clip_image.mask)*bckreg*cr_mask)
-            print('New func2d_fit_val: {0} seconds'.format(time.clock() - t))
+#            print('New func2d_fit_val: {0} seconds'.format(time.clock() - t))
             # Some fits are really wonky ... in both methods
 #            if np.sum(bgframe != _bgframe) != 0:
 #                plt.imshow(np.ma.log10(sciframe), origin='lower', interpolation='nearest',

--- a/pypit/arextract.py
+++ b/pypit/arextract.py
@@ -1,5 +1,7 @@
 from __future__ import (print_function, absolute_import, division, unicode_literals)
 
+import time
+from matplotlib import pyplot as plt
 import copy
 import numpy as np
 from astropy import units as u
@@ -91,7 +93,53 @@ def boxcar(slf, det, specobjs, sciframe, varframe, skyframe, crmask, scitrace):
             mask_sci = np.ma.array(sciframe, mask=bg_mask, fill_value=0.)
             clip_image = sigma_clip(mask_sci, axis=1, sigma=3.)  # For the mask only
             # Fit
-            bgframe = arcyutils.func2d_fit_val(bgfit, sciframe, (~clip_image.mask)*bckreg*cr_mask, bgfitord)
+            print('calling func2d_fit_val')
+            t = time.clock()
+            _bgframe = arcyutils.func2d_fit_val(bgfit, sciframe,
+                                                (~clip_image.mask)*bckreg*cr_mask, bgfitord)
+            print('Old func2d_fit_val: {0} seconds'.format(time.clock() - t))
+            t = time.clock()
+            bgframe = new_func2d_fit_val(sciframe, bgfitord, x=bgfit,
+                                         w=(~clip_image.mask)*bckreg*cr_mask)
+            print('New func2d_fit_val: {0} seconds'.format(time.clock() - t))
+            # Some fits are really wonky ... in both methods
+#            if np.sum(bgframe != _bgframe) != 0:
+#                plt.imshow(np.ma.log10(sciframe), origin='lower', interpolation='nearest',
+#                           aspect='auto')
+#                plt.colorbar()
+#                plt.show()
+#                w=(~clip_image.mask)*bckreg*cr_mask
+#                plt.imshow(np.ma.log10(sciframe*w), origin='lower', interpolation='nearest',
+#                           aspect='auto')
+#                plt.colorbar()
+#                plt.show()
+#                plt.imshow(np.ma.log10(_bgframe), origin='lower',
+#                           interpolation='nearest', aspect='auto')
+#                plt.colorbar()
+#                plt.show()
+#                plt.imshow(np.ma.log10(bgframe), origin='lower',
+#                           interpolation='nearest', aspect='auto')
+#                plt.colorbar()
+#                plt.show()
+#                plt.imshow(np.ma.log10(np.absolute(bgframe-_bgframe)), origin='lower',
+#                           interpolation='nearest', aspect='auto')
+#                plt.colorbar()
+#                plt.show()
+#                plt.imshow(np.ma.log10(np.ma.divide(bgframe,_bgframe)), origin='lower',
+#                           interpolation='nearest', aspect='auto')
+#                plt.colorbar()
+#                plt.show()
+#
+#                d = np.amax(np.absolute(bgframe-_bgframe), axis=1)
+#                i = np.argmax(d)
+#                plt.plot(bgfit, sciframe[i,:])
+#                plt.plot(bgfit, sciframe[i,:]*w[i,:])
+#                plt.plot(bgfit, bgframe[i,:])
+#                plt.plot(bgfit, _bgframe[i,:])
+#                plt.show()
+#
+#            assert np.sum(bgframe != _bgframe) == 0, 'Difference between old and new func2d_fit_val'
+
             # Weights
             weight = objreg*mask_slit
             sumweight = np.sum(weight, axis=1)
@@ -439,3 +487,60 @@ def boxcar_cen(slf, det, img):
         censpec = censpec[:, 0].flatten()
     # Return
     return censpec
+
+
+def new_func2d_fit_val(y, order, x=None, w=None):
+    """
+    Fit a polynomial to each column in y.
+
+    if y is 2D, always fit along columns
+
+    test if y is a MaskedArray
+    """
+    # Check input
+    if y.ndim > 2:
+        msgs.error('y cannot have more than 2 dimensions.')
+
+    _y = np.atleast_2d(y)
+    ny, npix = _y.shape
+
+    # Set the x coordinates
+    if x is None:
+        _x = np.linspace(-1,1,npix)
+    else:
+        if x.ndim != 1:
+            msgs.error('x must be a vector')
+        if x.size != npix:
+            msgs.error('Input x must match y vector or column length.')
+        _x = x.copy()
+
+    # Generate the Vandermonde matrix
+    vand = np.polynomial.polynomial.polyvander(_x, order)
+
+    # Fit with appropriate weighting
+    if w is None:
+        # Fit without weights
+        c = np.linalg.lstsq(vand, _y.T)[0]
+        ym = np.sum(c[:,:,None] * vand.T[:,None,:], axis=0)
+    elif w.ndim == 1:
+        # Fit with the same weight for each vector
+        _vand = w[:,None] * vand
+        __y = w[None,:] * _y
+        c = np.linalg.lstsq(_vand, __y.T)[0]
+        ym = np.sum(c[:,:,None] * vand.T[:,None,:], axis=0)
+    else:
+        # Fit with different weights for each vector
+        if w.shape != y.shape:
+            msgs.error('Input w must match y axis length or y shape.')
+        # Prep the output model
+        ym = np.empty(_y.shape, dtype=float)
+        __y = w * _y
+        for i in range(ny):
+            # Fit with the same weight for each vector
+            _vand = w[i,:,None] * vand
+            c = np.linalg.lstsq(_vand, __y[i,:])[0]
+            ym[i,:] = np.sum(c[:,None] * vand.T[:,:], axis=0)
+
+    # Return the model with the appropriate shape
+    return ym if y.ndim == 2 else ym[0,:]
+

--- a/pypit/arextract.py
+++ b/pypit/arextract.py
@@ -534,9 +534,10 @@ def new_func2d_fit_val(y, order, x=None, w=None):
             msgs.error('Input w must match y axis length or y shape.')
         # Prep the output model
         ym = np.empty(_y.shape, dtype=float)
+        # Weight the data
         __y = w * _y
         for i in range(ny):
-            # Fit with the same weight for each vector
+            # Weight the Vandermonde matrix for this y vector
             _vand = w[i,:,None] * vand
             c = np.linalg.lstsq(_vand, __y[i,:])[0]
             ym[i,:] = np.sum(c[:,None] * vand.T[:,:], axis=0)

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -1788,14 +1788,14 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
     # Old cr_screen can yield nan pixels, new one does not, meaning that
     # there are differences between the returned arrays.  For all
     # non-nan pixels, the two algorithms are identical.
-    print('calling cr_screen')
-    t = time.clock()
-    _sigimg  = arcyproc.cr_screen(filty,0.0)
-    print('Old cr_screen: {0} seconds'.format(time.clock() - t))
+#    print('calling cr_screen')
+#    t = time.clock()
+#    _sigimg  = arcyproc.cr_screen(filty,0.0)
+#    print('Old cr_screen: {0} seconds'.format(time.clock() - t))
 #    print(np.sum(np.invert(np.isfinite(_sigimg))))
-    t = time.clock()
+#    t = time.clock()
     sigimg  = new_cr_screen(filty)
-    print('New cr_screen: {0} seconds'.format(time.clock() - t))
+#    print('New cr_screen: {0} seconds'.format(time.clock() - t))
 #    print(np.sum(np.invert(np.isfinite(sigimg))))
 #    if np.sum(_sigimg != sigimg) != 0:
 #        plt.imshow(_sigimg, origin='lower', interpolation='nearest', aspect='auto')

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -196,19 +196,19 @@ def bg_subtraction(slf, det, sciframe, varframe, crpix, tracemask=None,
     errframe = np.sqrt(varframe)
     # Find which pixels are within the order edges
     msgs.info("Identifying pixels within each order")
-    print('calling order_pixels')
-    t = time.clock()
-    _ordpix = arcyutils.order_pixels(slf._pixlocn[det-1],
-                                     slf._lordloc[det-1]*0.95+slf._rordloc[det-1]*0.05,
-                                     slf._lordloc[det-1]*0.05+slf._rordloc[det-1]*0.95)
-    print('Old order_pixels: {0} seconds'.format(time.clock() - t))
-    t = time.clock()
+#    print('calling order_pixels')
+#    t = time.clock()
+#    _ordpix = arcyutils.order_pixels(slf._pixlocn[det-1],
+#                                     slf._lordloc[det-1]*0.95+slf._rordloc[det-1]*0.05,
+#                                     slf._lordloc[det-1]*0.05+slf._rordloc[det-1]*0.95)
+#    print('Old order_pixels: {0} seconds'.format(time.clock() - t))
+#    t = time.clock()
     ordpix = new_order_pixels(slf._pixlocn[det-1],
                               slf._lordloc[det-1]*0.95+slf._rordloc[det-1]*0.05,
                               slf._lordloc[det-1]*0.05+slf._rordloc[det-1]*0.95)
-    print('New order_pixels: {0} seconds'.format(time.clock() - t))
-    assert np.sum(_ordpix != ordpix) == 0, \
-                    'Difference between old and new order_pixels'
+#    print('New order_pixels: {0} seconds'.format(time.clock() - t))
+#    assert np.sum(_ordpix != ordpix) == 0, \
+#                    'Difference between old and new order_pixels'
 
     msgs.info("Applying bad pixel mask")
     ordpix *= (1-slf._bpix[det-1].astype(np.int)) * (1-crpix.astype(np.int))
@@ -451,15 +451,15 @@ def flatnorm(slf, det, msflat, maskval=-999999.9, overpix=6, plotdesc=""):
     # Find which pixels are within the order edges
     msgs.info("Identifying pixels within each order")
 
-    print('calling order_pixels')
-    t = time.clock()
-    _ordpix = arcyutils.order_pixels(slf._pixlocn[det-1], slf._lordloc[det-1], slf._rordloc[det-1])
-    print('Old order_pixels: {0} seconds'.format(time.clock() - t))
-    t = time.clock()
+#    print('calling order_pixels')
+#    t = time.clock()
+#    _ordpix = arcyutils.order_pixels(slf._pixlocn[det-1], slf._lordloc[det-1], slf._rordloc[det-1])
+#    print('Old order_pixels: {0} seconds'.format(time.clock() - t))
+#    t = time.clock()
     ordpix = new_order_pixels(slf._pixlocn[det-1], slf._lordloc[det-1], slf._rordloc[det-1])
-    print('New order_pixels: {0} seconds'.format(time.clock() - t))
-    assert np.sum(_ordpix != ordpix) == 0, \
-                    'Difference between old and new order_pixels'
+#    print('New order_pixels: {0} seconds'.format(time.clock() - t))
+#    assert np.sum(_ordpix != ordpix) == 0, \
+#                    'Difference between old and new order_pixels'
 
     msgs.info("Applying bad pixel mask")
     ordpix *= (1-slf._bpix[det-1].astype(np.int))
@@ -1186,17 +1186,17 @@ def slit_pixels(slf, frameshape, det):
     for o in range(nslits):
         lordloc = slf._lordloc[det - 1][:, o]
         rordloc = slf._rordloc[det - 1][:, o]
-        print('calling locate_order')
-        t = time.clock()
-        _ordloc = arcytrace.locate_order(lordloc, rordloc, frameshape[0], frameshape[1],
-                                         settings.argflag['trace']['slits']['pad'])
-        print('Old locate_order: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling locate_order')
+#        t = time.clock()
+#        _ordloc = arcytrace.locate_order(lordloc, rordloc, frameshape[0], frameshape[1],
+#                                         settings.argflag['trace']['slits']['pad'])
+#        print('Old locate_order: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         ordloc = new_locate_order(lordloc, rordloc, frameshape[0], frameshape[1],
                                   settings.argflag['trace']['slits']['pad'])
-        print('New locate_order: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_ordloc != ordloc) == 0, \
-                    'Difference between old and new locate_order'
+#        print('New locate_order: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_ordloc != ordloc) == 0, \
+#                    'Difference between old and new locate_order'
         word = np.where(ordloc != 0)
         if word[0].size == 0:
             msgs.warn("There are no pixels in slit {0:d}".format(o + 1))
@@ -1836,14 +1836,14 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
     sigmask[np.where(sigsmth>sigclip)] = True
     crmask = np.logical_and(crmask, sigmask)
     msgs.info("Growing cosmic ray mask by 1 pixel")
-    print('calling grow_masked')
-    t = time.clock()
-    _crmask = arcyutils.grow_masked(crmask.astype(np.float), grow, 1.0)
-    print('Old grow_masked: {0} seconds'.format(time.clock() - t))
-    t = time.clock()
+#    print('calling grow_masked')
+#    t = time.clock()
+#    _crmask = arcyutils.grow_masked(crmask.astype(np.float), grow, 1.0)
+#    print('Old grow_masked: {0} seconds'.format(time.clock() - t))
+#    t = time.clock()
     crmask = new_grow_masked(crmask.astype(np.float), grow, 1.0)
-    print('New grow_masked: {0} seconds'.format(time.clock() - t))
-    assert np.sum(_crmask != crmask) == 0, 'Difference between old and new grow_masked'
+#    print('New grow_masked: {0} seconds'.format(time.clock() - t))
+#    assert np.sum(_crmask != crmask) == 0, 'Difference between old and new grow_masked'
 
     return crmask
 

--- a/pypit/arproc.py
+++ b/pypit/arproc.py
@@ -22,6 +22,9 @@ from pypit import ardebug as debugger
 # Logging
 msgs = armsgs.get_logger()
 
+#KBW TESTING
+import time
+
 
 def background_subtraction(slf, sciframe, varframe, slitn, det, refine=0.0):
     """ Generate a frame containing the background sky spectrum
@@ -1710,7 +1713,35 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
     filt  = ndimage.sobel(sciframe, axis=1, mode='constant')
     filty = ndimage.sobel(filt/np.sqrt(np.abs(sciframe)), axis=0, mode='constant')
     filty[np.where(np.isnan(filty))]=0.0
-    sigimg  = arcyproc.cr_screen(filty,0.0)
+
+#    t = time.clock()
+#    sigimg  = arcyproc.cr_screen(filty,0.0)
+#    print('Old cr_screen: {0} seconds'.format(time.clock() - t))
+#
+#    t = time.clock()
+#    new_sigimg  = new_cr_screen(filty,0.0)
+#    print('New cr_screen: {0} seconds'.format(time.clock() - t))
+#    sigimg  = arcyproc.cr_screen(filty,0.0)
+    sigimg  = new_cr_screen(filty)
+
+#    print(sigimg.shape)
+#    print(new_sigimg.shape)
+#    print(np.ma.mean(np.ma.log10(sigimg)))
+#    print(np.ma.mean(np.ma.log10(new_sigimg)))
+#    print(np.ma.mean(np.ma.log10(sigimg)-np.ma.log10(new_sigimg)))
+#
+#    plt.imshow(np.ma.log10(sigimg), origin='lower', interpolation='nearest', aspect='auto')
+#    plt.colorbar()
+#    plt.show()
+#
+#    plt.imshow(np.ma.log10(new_sigimg), origin='lower', interpolation='nearest', aspect='auto')
+#    plt.colorbar()
+#    plt.show()
+#
+#    plt.imshow(np.ma.log10(new_sigimg)-np.ma.log10(sigimg), origin='lower', interpolation='nearest', aspect='auto')
+#    plt.colorbar()
+#    plt.show()
+
     sigsmth = ndimage.filters.gaussian_filter(sigimg,1.5)
     sigsmth[np.where(np.isnan(sigsmth))]=0.0
     sigmask = np.cast['bool'](np.zeros(sciframe.shape))
@@ -1719,6 +1750,46 @@ def lacosmic(slf, fitsdict, det, sciframe, scidx, maxiter=1, grow=1.5, maskval=-
     msgs.info("Growing cosmic ray mask by 1 pixel")
     crmask = arcyutils.grow_masked(crmask.astype(np.float), grow, 1.0)
     return crmask
+
+
+def new_cr_screen(a, mask_value=0.0, spatial_axis=1):
+    r"""
+    Calculate the significance of pixel deviations from the median along
+    the spatial direction.
+
+    No type checking is performed of the input array; however, the
+    function assumes floating point values.
+
+    Args:
+        a (numpy.ndarray): Input 2D array
+        mask_value (float): (**Optional**) Values to ignore during the
+            calculation of the median.  Default is 0.0.
+        spatial_axis (int): (**Optional**) Axis along which to calculate
+            the median.  Default is 1.
+
+    Returns:
+        numpy.ndarray: Returns a map of :math:`|\Delta_{i,j}|/\sigma_j`,
+        where :math:`\Delta_{i,j}` is the difference between the pixel
+        value and the median along axis :math:`i` and :math:`\sigma_j`
+        is robustly determined using the median absolute deviation,
+        :math:`sigma_j = 1.4826 MAD`.
+    """
+    # Check input
+    if len(a.shape) != 2:
+        msgs.error('Input array must be two-dimensional.')
+    if spatial_axis not in [0,1]:
+        msgs.error('Spatial axis must be 0 or 1.')
+
+    # Mask the pixels equal to mask value: should use np.isclose()
+    _a = np.ma.MaskedArray(a, mask=(a==mask_value))
+    # Get the median along the spatial axis
+    meda = np.ma.median(_a, axis=spatial_axis)
+    # Get a robust measure of the standard deviation using the median
+    # absolute deviation; 1.4826 factor is the ratio of sigma/MAD
+    d = np.absolute(_a - meda[:,None])
+    mada = 1.4826*np.ma.median(d, axis=spatial_axis)
+    # Return the ratio of the difference to the standard deviation
+    return np.ma.divide(d, mada[:,None]).filled(0.0)
 
 
 def gain_frame(slf, det):

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -14,6 +14,8 @@ import scipy.interpolate as interp
 import scipy.ndimage as ndimage
 from collections import Counter
 
+from pypit.filter import BoxcarFilter
+
 # Logging
 msgs = armsgs.get_logger()
 
@@ -123,16 +125,15 @@ def assign_slits(binarr, edgearr, ednum=100000, lor=-1):
                 break
             pks = wpk+2  # Shifted by 2 because of the peak finding algorithm above
             print('calling find_peak_limits')
-
             t = time.clock()
-            pedges = arcytrace.find_peak_limits(smedgehist, pks)
+            _pedges = arcytrace.find_peak_limits(smedgehist, pks)
             print('Old find_peak_limits: {0} seconds'.format(time.clock() - t))
-            print(pedges.shape)
-            print(pedges[:,0])
             t = time.clock()
             pedges = new_find_peak_limits(smedgehist, pks)
             print('New find_peak_limits: {0} seconds'.format(time.clock() - t))
-            exit()
+            assert np.sum(_pedges != pedges) == 0, \
+                    'Difference between old and new find_peak_limits'
+
             if np.all(pedges[:, 1]-pedges[:, 0] == 0):
                 # Remaining peaks have no width
                 break
@@ -300,6 +301,7 @@ def expand_slits(slf, mstrace, det, ordcen, extord):
     # Calculate the pixel locations of th eorder edges
     pixcen = phys_to_pix(ordcen, slf._pixlocn[det - 1], 1)
     msgs.info("Expanding slit traces to slit edges")
+    exit()
     mordwid, pordwid = arcytrace.expand_slits(mstrace, pixcen, extord.astype(np.int))
     # Fit a function for the difference between left edge and the centre trace
     ldiff_coeff, ldiff_fit = arutils.polyfitter2d(mordwid, mask=-1,
@@ -538,7 +540,51 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
     msgs.info("Estimating object profiles")
     # Smooth the S/N frame
     smthby, rejhilo = tracepar['smthby'], tracepar['rejhilo']
-    rec_sigframe_bin = arcyutils.smooth_x(rec_sciframe/np.sqrt(rec_varframe), 1.0-rec_crmask, smthby, rejhilo, maskval)
+    print('calling smooth_x')
+    t = time.clock()
+    _rec_sigframe_bin = arcyutils.smooth_x(rec_sciframe/np.sqrt(rec_varframe), 1.0-rec_crmask,
+                                           smthby, rejhilo, maskval)
+    print('Old smooth_x: {0} seconds'.format(time.clock() - t))
+    tmp = np.ma.MaskedArray(rec_sciframe/np.sqrt(rec_varframe), mask=rec_crmask.astype(bool))
+    # TODO: Add rejection to BoxcarFilter?
+    t = time.clock()
+    rec_sigframe_bin = BoxcarFilter(smthby).smooth(tmp.T).T
+    print('BoxcarFilter: {0} seconds'.format(time.clock() - t))
+#    t = time.clock()
+#    rec_sigframe_bin = new_smooth_x(rec_sciframe/np.sqrt(rec_varframe), 1.0-rec_crmask, smthby,
+#                                    rejhilo, maskval)
+#    print('New smooth_x: {0} seconds'.format(time.clock() - t))
+    # TODO: BoxcarFilter and smooth_x will provide different results.
+    # Need to assess their importance.
+#    if np.sum(_rec_sigframe_bin != rec_sigframe_bin) != 0:
+#
+#        plt.plot(tmp[:,200])
+#        plt.plot(rec_sigframe_bin[:,200])
+#        plt.plot(_rec_sigframe_bin[:,200])
+#        plt.show()
+#
+#        plt.imshow( np.ma.MaskedArray(_rec_sigframe_bin, mask=rec_crmask.astype(bool)),
+#                   origin='lower', interpolation='nearest', aspect='auto')
+#        plt.colorbar()
+#        plt.show()
+#        plt.imshow(np.ma.MaskedArray(rec_sigframe_bin, mask=rec_crmask.astype(bool)),
+#                   origin='lower', interpolation='nearest', aspect='auto')
+#        plt.colorbar()
+#        plt.show()
+#        plt.imshow(np.ma.MaskedArray(_rec_sigframe_bin-rec_sigframe_bin,
+#                                     mask=rec_crmask.astype(bool)),
+#                   origin='lower', interpolation='nearest', aspect='auto')
+#        plt.colorbar()
+#        plt.show()
+#        t = np.ma.divide(_rec_sigframe_bin,rec_sigframe_bin)
+#        t[rec_crmask.astype(bool)] = np.ma.masked
+#        plt.imshow(t,
+#                   origin='lower', interpolation='nearest', aspect='auto')
+#        plt.colorbar()
+#        plt.show()
+#    assert np.sum(_rec_sigframe_bin != rec_sigframe_bin) == 0, \
+#                    'Difference between old and new smooth_x'
+
     #rec_varframe_bin = arcyutils.smooth_x(rec_varframe, 1.0-rec_crmask, smthby, rejhilo, maskval)
     #rec_sigframe_bin = np.sqrt(rec_varframe_bin/(smthby-2.0*rejhilo))
     #sigframe = rec_sciframe_bin*(1.0-rec_crmask)/rec_sigframe_bin
@@ -578,13 +624,27 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
         trcprof2 = np.mean(rec_sciframe, axis=0)
         objl, objr, bckl, bckr = find_obj_minima(trcprof2, triml=triml, trimr=trimr, nsmooth=nsmooth)
     elif settings.argflag['trace']['object']['find'] == 'standard':
-#        print('calling find_objects')
-#        t = time.clock()
-#        objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
-#        print('Old find_objects: {0} seconds'.format(time.clock() - t))
-#        t = time.clock()
+        print('calling find_objects')
+        t = time.clock()
+        _objl, _objr, _bckl, _bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+        print('Old find_objects: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
         objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
-#        print('New find_objects: {0} seconds'.format(time.clock() - t))
+        print('New find_objects: {0} seconds'.format(time.clock() - t))
+#        print('objl:', objl)
+#        print('_objl:', _objl)
+#        print('objr:', objr)
+#        print('_objr:', _objr)
+#        print(_objl.shape, objl.shape)
+#        print(_objr.shape, objr.shape)
+#        print(np.sum(_objl != objl))
+#        print(np.sum(_objr != objr))
+        assert np.sum(_objl != objl) == 0, 'Difference between old and new find_objects, objl'
+        assert np.sum(_objr != objr) == 0, 'Difference between old and new find_objects, objr'
+        assert np.sum(_bckl != bckl) == 0, 'Difference between old and new find_objects, bckl'
+        assert np.sum(_bckr != bckr) == 0, 'Difference between old and new find_objects, bckr'
+#        objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
+
     else:
         msgs.error("Bad object identification algorithm!!")
     if msgs._debug['trace_obj']:
@@ -715,6 +775,47 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
     return tracedict
 
 
+def new_find_between(edgdet, ledgem, ledgep, dirc):
+
+    if len(edgdet.shape) != 2:
+        msgs.error('Edge pixels array must be 2D.')
+    if len(ledgem.shape) != 1 or len(ledgep.shape) !=1:
+        msgs.error('Input must be 1D.')
+
+    sz_x, sz_y = edgdet.shape
+
+    # Setup the coefficient arrays
+    edgbtwn = np.full(3, -1, dtype=int)
+
+    for x in range(0,sz_x):
+        rng = np.sort([ledgem[x],ledgep[x]])
+        if not np.any(edgdet[x,slice(*rng)] > 0):
+            continue
+        e = edgdet[x,slice(*rng)][edgdet[x,slice(*rng)] > 0]
+        if edgbtwn[0] == -1:
+            edgbtwn[0] = e[0]
+        indx = e != edgbtwn[0]
+        if edgbtwn[1] == -1 and np.any(indx):
+            edgbtwn[1] = e[indx][0]
+
+    # If no right order edges were found between these two left order
+    # edges, find the next right order edge
+    if edgbtwn[0] == -1 and edgbtwn[1] == -1:
+        for x in range(0,sz_x):
+            ystrt = np.max([ledgem[x],ledgep[x]])
+            if dirc == 1:
+                emin = np.min(edgdet[x,ystrt:][edgdet[x,ystrt:] > 0])
+                if edgbtwn[2] == -1 or emin < edgbtwn[2]:
+                    edgbtwn[2] = emin
+            else:
+                emax = np.max(edgdet[x,:ystrt+1][edgdet[x,:ystrt+1] > 0])
+                if edgbtwn[2] == -1 or emax > edgbtwn[2]:
+                    edgbtwn[2] = emax
+
+    # Now return the array
+    return edgbtwn
+
+
 def new_find_objects(profile, bgreg, stddev):
     """
     Find significantly detected objects in the profile array
@@ -743,11 +844,14 @@ def new_find_objects(profile, bgreg, stddev):
     while np.any(gt_5_sigma & np.invert(_profile.mask)):
         # Find next maximum flux point
         imax = np.ma.argmax(_profile)
-        maxv = _profile[imax]
         # Find the valid source pixels around the peak
         f = np.arange(sz_x)[np.roll(not_gt_3_sigma, -imax)]
-        objl[obj] = imax-sz_x+f[-1]
-        objr[obj] = f[0]+imax
+        # TODO: the ifs below feel like kludges to match old
+        # find_objects function.  In particular, should objr be treated
+        # as exclusive or inclusive?
+        objl[obj] = imax-sz_x+f[-1] if imax-sz_x+f[-1] > 0 else 1
+        objr[obj] = f[0]+imax if f[0]+imax < sz_x else sz_x-1
+#        print('object found: ', imax, f[-1], objl[obj], f[0], objr[obj], sz_x)
         # Mask source pixels and increment for next iteration
         has_obj[objl[obj]:objr[obj]+1] = True
         _profile[objl[obj]:objr[obj]+1] = np.ma.masked
@@ -778,69 +882,59 @@ def new_find_peak_limits(hist, pks):
     Find all values between the zeros of hist
 
     hist and pks are expected to be 1d vectors
-
     """
-
-    sz_i = pks.shape[0]
-    sz_h = hist.shape[0]
-
-    edges = np.zeros((sz_i,2), dtype=int)
-
-    indx = np.ma.MaskedArray(np.array([np.arange(sz_h)]*sz_i),
-                             mask=(hist == 0)[None,:] | (np.arange(sz_h)[None,:] > pks[:,None]))
-
-    plt.imshow(indx, origin='lower', interpolation='nearest', aspect='auto')
-    plt.show()
-
-    print(hist)
-
-    print(pks[0])
-    print(indx[0,np.invert(indx.mask[0,:])])
-
-    print(pks[1])
-    print(indx[1,np.invert(indx.mask[1,:])])
-    exit()
-    print(sz_i, sz_h)
-    print(pks)
-    print(indx.shape)
-    edges[:,0] = np.ma.amin(indx, axis=1)
-    print(edges[:,0])
-    exit()
-
-    hi_indx = hist_ne_0[None,:] & (np.arange(sz_h)[None,:] > pks[:,None])
-
-
-    for ii in range(0, sz_i):
-
-        indx = (hist != 0) & (np.arange(sz_h) <= pks[ii])
-
-        # Search below the peak
-        lim = pks[ii]
-        while True:
-            if lim < 0:
-                break
-            if hist[lim] == 0:
-                break
-            lim -= 1
-        # Store the limit
-        edges[ii, 0] = lim
-        # Search above the peak
-        lim = pks[ii]
-        while True:
-            if lim > sz_h-1:
-                break
-            if hist[lim] == 0:
-                break
-            lim += 1
-        # Store the limit
-        edges[ii, 1] = lim
+    if len(hist.shape) != 1 or len(pks.shape) != 1:
+        msgs.error('Arrays provided to find_peak_limits must be vectors.')
+    # Pixel indices in hist for each peak
+    hn = np.arange(hist.shape[0])
+    indx = np.ma.MaskedArray(np.array([hn]*pks.shape[0]))
+    # Instantiate output
+    edges = np.zeros((pks.shape[0],2), dtype=int)
+    # Find the left edges
+    indx.mask = (hist != 0)[None,:] | (hn[None,:] > pks[:,None])
+    edges[:,0] = np.ma.amax(indx, axis=1)
+    # Find the right edges
+    indx.mask = (hist != 0)[None,:] | (hn[None,:] < pks[:,None])
+    edges[:,1] = np.ma.amin(indx, axis=1)
     return edges
 
 
-def new_ignore_orders(edgdet, fracpix, lmin, lmax, rmin, rmax):
+def new_find_shift(mstrace, minarr, lopos, diffarr, numsrch):
 
-    sz_x = edgdet.shape[0]
-    sz_y = edgdet.shape[1]
+    sz_y = mstrace.shape[1]
+    maxcnts = -999999.9
+    shift = 0
+    d = mstrace - minarr[:,None]
+
+    for s in range(0,numsrch):
+        cnts = 0.0
+
+        ymin = lopos + s
+        ymin[ymin < 0] = 0
+        ymax = ymin + diffarr
+        ymax[ymax > sz_y] = sz_y
+
+        indx = ymax > ymin
+
+        if np.sum(indx) == 0:
+            continue
+
+        cnts = np.sum([ np.sum(t[l:h]) for t,l,h in zip(d[indx], ymin[indx], ymax[indx]) ]) \
+                    / np.sum(ymax[indx]-ymin[indx])
+        if cnts > maxcnts:
+            maxcnts = cnts
+            shift = s
+
+    return shift
+
+
+def new_ignore_orders(edgdet, fracpix, lmin, lmax, rmin, rmax):
+    """
+    .. warning::
+
+        edgdet is alted by the function.
+    """
+    sz_x, sz_y = edgdet.shape
 
     lsize = lmax-lmin+1
     larr = np.zeros((2,lsize), dtype=int)
@@ -882,6 +976,266 @@ def new_ignore_orders(edgdet, fracpix, lmin, lmax, rmin, rmax):
     rxc = rsize-1-rindx[-1]
 
     return lnc, lxc, rnc, rxc, larr, rarr
+
+
+def new_limit_yval(yc, maxv):
+    yn = 0 if yc == 0 else (-yc if yc < 3 else -3)
+    yx = maxv-yc if yc > maxv-4 and yc < maxv else 4
+    return yn, yx
+
+
+def new_match_edges(edgdet, ednum):
+    """
+    ednum is a large dummy number used for slit edge assignment. ednum
+    should be larger than the number of edges detected
+
+    This function alters edgdet!
+    """
+    # mr is the minimum number of acceptable pixels required to form the
+    # detection of an order edge
+    mr = 5
+    mrxarr = np.zeros(mr, dtype=int)
+    mryarr = np.zeros(mr, dtype=int)
+
+    sz_x, sz_y = edgdet.shape
+
+    lcnt = 2*ednum
+    rcnt = 2*ednum
+    for y in range(sz_y):
+        for x in range(sz_x):
+            if edgdet[x,y] != -1 and edgdet[x,y] != 1:
+                continue
+
+            anyt = 0
+            left = edgdet[x,y] == -1
+
+            # Search upwards from x,y
+            xs = x + 1
+            yt = y
+            while xs <= sz_x-1:
+                xr = 10 if xs + 10 < sz_x else sz_x - xs - 1
+                yn, yx = new_limit_yval(yt, sz_y)
+
+                suc = 0
+                for s in range(xs, xs+xr):
+                    suc = 0
+                    for t in range(yt + yn, yt + yx):
+                        if edgdet[s, t] == -1 and left:
+                            edgdet[s, t] = -lcnt
+                        elif edgdet[s, t] == 1 and not left:
+                            edgdet[s, t] = rcnt
+                        else:
+                            continue
+
+                        suc = 1
+                        if anyt < mr:
+                            mrxarr[anyt] = s
+                            mryarr[anyt] = t
+                        anyt += 1
+                        yt = t
+                        break
+
+                    if suc == 1:
+                        xs = s + 1
+                        break
+                if suc == 0: # The trace is lost!
+                    break
+
+            # Search downwards from x,y
+            xs = x - 1
+            yt = y
+            while xs >= 0:
+                xr = xs if xs-10 < 0 else 10
+                yn, yx = new_limit_yval(yt, sz_y)
+
+                suc = 0
+                for s in range(0, xr):
+                    suc = 0
+                    for t in range(yt+yn, yt+yx):
+                        if edgdet[xs-s, t] == -1 and left:
+                            edgdet[xs-s, t] = -lcnt
+                        elif edgdet[xs-s, t] == 1 and not left:
+                            edgdet[xs-s, t] = rcnt
+                        else:
+                            continue
+
+                        suc = 1
+                        if anyt < mr:
+                            mrxarr[anyt] = xs-s
+                            mryarr[anyt] = t
+                        anyt += 1
+                        yt = t
+                        break
+
+                    if suc == 1:
+                        xs = xs - s - 1
+                        break
+                if suc == 0: # The trace is lost!
+                    break
+
+            if anyt > mr and left:
+                edgdet[x, y] = -lcnt
+                lcnt = lcnt + 1
+            elif anyt > mr and not left:
+                edgdet[x, y] = rcnt
+                rcnt = rcnt + 1
+            else:
+                edgdet[x, y] = 0
+                for s in range(anyt):
+                    if mrxarr[s] != 0 and mryarr[s] != 0:
+                        edgdet[mrxarr[s], mryarr[s]] = 0
+    return lcnt-2*ednum, rcnt-2*ednum
+
+
+def new_mean_weight(array, weight, rejhilo, maskval):
+    _a = array if rejhilo == 0 else np.sort(array)
+    sumw = np.sum(weight[rejhilo:-rejhilo])
+    sumwa = np.sum(weight[rejhilo:-rejhilo]*_a[rejhilo:-rejhilo])
+    return maskval if sumw == 0.0 else sumwa/sumw
+
+
+def new_minbetween(mstrace, loord, hiord):
+    # TODO: Check shapes
+    ymin = np.clip(loord, 0, mstrace.shape[1])
+    ymax = np.clip(hiord, 0, mstrace.shape[1])
+    minarr = np.zeros(mstrace.shape[0])
+    indx = ymax > ymin
+    minarr[indx] = np.array([ np.amin(t[l:h]) 
+                                for t,l,h in zip(mstrace[indx], ymin[indx], ymax[indx]) ])
+    return minarr
+
+
+def new_phys_to_pix(array, diff):
+    if len(array.shape) > 2:
+        msgs.error('Input array must have two dimensions or less!')
+    if len(diff.shape) != 1:
+        msgs.error('Input difference array must be 1D!')
+    _array = np.atleast_2d(array)
+    doravel = len(array.shape) != 2
+    pix = np.argmin(np.absolute(_array[:,:,None] - diff[None,None,:]), axis=2)
+    return pix.ravel() if doravel else pix
+
+    sz_a, sz_n = _array.shape
+    sz_d = diff.size
+
+    pix = np.zeros((sz_a,sz_n), dtype=int)
+    for n in range(0,sz_n):
+        for a in range(0,sz_a):
+            mind = 0
+            mindv = _array[a,n]-diff[0]
+
+            for d in range(1,sz_d):
+                test = _array[a,n]-diff[d]
+                if test < 0.0: test *= -1.0
+                if test < mindv:
+                    mindv = test
+                    mind = d
+                if _array[a,n]-diff[d] < 0.0: break
+            pix[a,n] = mind
+    return pix.ravel() if doravel else pix
+
+# Weighted boxcar smooothing with rejection
+def new_smooth_x(array, weight, fact, rejhilo, maskval):
+    hf = fact // 2
+
+    sz_x, sz_y = array.shape
+
+    smtarr = np.zeros((sz_x,sz_y), dtype=float)
+    medarr = np.zeros((fact+1), dtype=float)
+    wgtarr = np.zeros((fact+1), dtype=float)
+
+    for y in range(sz_y):
+        for x in range(sz_x):
+            for b in range(fact+1):
+                if (x+b-hf < 0) or (x+b-hf >= sz_x):
+                    wgtarr[b] = 0.0
+                else:
+                    medarr[b] = array[x+b-hf,y]
+                    wgtarr[b] = weight[x+b-hf,y]
+            smtarr[x,y] = new_mean_weight(medarr, wgtarr, rejhilo, maskval)
+    return smtarr
+
+
+def new_tilts_image(tilts, lordloc, rordloc, pad, sz_y):
+    """
+    Using the tilt (assumed to be fit with a first order polynomial)
+    generate an image of the tilts for each slit.
+
+    Parameters
+    ----------
+    tilts : ndarray
+      An (m x n) 2D array specifying the tilt (i.e. gradient) at each
+      pixel along the spectral direction (m) for each slit (n).
+    lordloc : ndarray
+      Location of the left slit edges
+    rordloc : ndarray
+      Location of the right slit edges
+    pad : int
+      Set the tilts within each slit, and extend a number of pixels
+      outside the slit edges (this number is set by pad).
+    sz_y : int
+      Number of detector pixels in the spatial direction.
+
+    Returns
+    -------
+    tiltsimg : ndarray
+      An image the same size as the science frame, containing values from 0-1.
+      0/1 corresponds to the bottom/top of the detector (in the spectral direction),
+      and constant wavelength is represented by a single value from 0-1.
+
+    """
+    sz_x, sz_o = tilts.shape
+    dszx = (sz_x-1.0)
+
+    tiltsimg = np.zeros((sz_x,sz_y), dtype=float)
+    for o in range(sz_o):
+        for x in range(sz_x):
+            ow = (rordloc[x,o]-lordloc[x,o])/2.0
+            oc = (rordloc[x,o]+lordloc[x,o])/2.0
+            ymin = int(oc-ow) - pad
+            ymax = int(oc+ow) + 1 + pad
+            # Check we are in bounds
+            if ymin < 0:
+                ymin = 0
+            elif ymax < 0:
+                continue
+            if ymax > sz_y-1:
+                ymax = sz_y-1
+            elif ymin > sz_y-1:
+                continue
+            # Set the tilt value at each pixel in this row
+            for y in range(ymin, ymax):
+                yv = (y-lordloc[x, o])/ow - 1.0
+                tiltsimg[x,y] = (tilts[x,o]*yv + x)/dszx
+    return tiltsimg
+    
+
+    sz_x, sz_o = tilts.shape
+    dszx = (sz_x-1.0)
+
+    ow = (rordloc-lordloc)/2.0
+    oc = (rordloc+lordloc)/2.0
+    
+    ymin = (oc-ow).astype(int) - pad
+    ymax = (oc+ow).astype(int) + 1 + pad
+
+    indx = (ymax >= 0) & (ymin < sz_y)
+    ymin[ymin < 0] = 0
+    ymax[ymax > sz_y-1] = sz_y-1
+
+    tiltsimg = np.zeros((sz_x,sz_y), dtype=float)
+
+    xv = np.arange(sz_x).astype(int)
+    for o in range(sz_o):
+        if np.sum(indx[:,o]) == 0:
+            continue
+        for x in xv[indx[:,o]]:
+            # Set the tilt value at each pixel in this row
+            for y in range(ymin[x,o], ymax[x,o]):
+                yv = (y-lordloc[x,o])/ow[x,o] - 1.0
+                tiltsimg[x,y] = (tilts[x,o]*yv + x)/dszx
+
+    return tiltsimg
 
 
 def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
@@ -1034,7 +1388,26 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
 
     # Assign a number to each of the edges
     msgs.info("Matching slit edges")
-    lcnt, rcnt = arcytrace.match_edges(edgearr, ednum)
+
+    _edgearr = edgearr.copy()
+    t = time.clock()
+    _lcnt, _rcnt = arcytrace.match_edges(_edgearr, ednum)
+    print('Old match_edges: {0} seconds'.format(time.clock() - t))
+    __edgearr = edgearr.copy()
+    t = time.clock()
+    lcnt, rcnt = new_match_edges(__edgearr, ednum)
+    print('New match_edges: {0} seconds'.format(time.clock() - t))
+#    print(lcnt, _lcnt, rcnt, _rcnt)
+#    print(np.sum(__edgearr != _edgearr))
+#    plt.imshow(_edgearr, origin='lower', interpolation='nearest', aspect='auto')
+#    plt.show()
+#    plt.imshow(__edgearr, origin='lower', interpolation='nearest', aspect='auto')
+#    plt.show()
+    assert np.sum(_lcnt != lcnt) == 0, 'Difference between old and new match_edges, lcnt'
+    assert np.sum(_rcnt != rcnt) == 0, 'Difference between old and new match_edges, rcnt'
+    assert np.sum(__edgearr != _edgearr) == 0, 'Difference between old and new match_edges, edgearr'
+    edgearr = __edgearr
+
     if lcnt >= ednum or rcnt >= ednum:
         msgs.error("Found more edges than allowed by ednum. Set ednum to a larger number.")
     if lcnt == 1:
@@ -1250,14 +1623,25 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
         msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0])))
         fracpix = int(settings.argflag['trace']['slits']['fracignore']*edgearr.shape[0])
 
-#        print('calling ignore_orders')
-#        t = time.clock()
-#        lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
-#        print('Old ignore_orders: {0} seconds'.format(time.clock() - t))
-#        t = time.clock()
-        lnc, lxc, rnc, rxc, ldarr, rdarr = new_ignore_orders(edgearr, fracpix, lmin, lmax, rmin,
+        print('calling ignore_orders')
+        t = time.clock()
+        _edgearr = edgearr.copy()
+        _lnc, _lxc, _rnc, _rxc, _ldarr, _rdarr = arcytrace.ignore_orders(_edgearr, fracpix, lmin, lmax, rmin, rmax)
+        print('Old ignore_orders: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        __edgearr = edgearr.copy()
+        lnc, lxc, rnc, rxc, ldarr, rdarr = new_ignore_orders(__edgearr, fracpix, lmin, lmax, rmin,
                                                              rmax)
-#        print('New ignore_orders: {0} seconds'.format(time.clock() - t))
+        print('New ignore_orders: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_lnc != lnc) == 0, 'Difference between old and new ignore_orders, lnc'
+        assert np.sum(_lxc != lxc) == 0, 'Difference between old and new ignore_orders, lxc'
+        assert np.sum(_rnc != rnc) == 0, 'Difference between old and new ignore_orders, rnc'
+        assert np.sum(_rxc != rxc) == 0, 'Difference between old and new ignore_orders, rxc'
+        assert np.sum(_ldarr != ldarr) == 0, 'Difference between old and new ignore_orders, ldarr'
+        assert np.sum(_rdarr != rdarr) == 0, 'Difference between old and new ignore_orders, rdarr'
+        assert np.sum(__edgearr != _edgearr) == 0, 'Difference between old and new ignore_orders, edgearr'
+
+        edgearr = __edgearr
 
         lmin += lnc
         rmin += rnc
@@ -1401,9 +1785,14 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
     if mnvalp > mnvalm:
         lvp = (arutils.func_val(lcoeff[:, lval+1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)
-        print('calling find_between')
-        exit()
-        edgbtwn = arcytrace.find_between(edgearr, lv, lvp, 1)
+        t = time.clock()
+        _edgbtwn = arcytrace.find_between(edgearr, lv, lvp, 1)
+        print('Old find_between: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        edgbtwn = new_find_between(edgearr, lv, lvp, 1)
+        print('New find_between: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_edgbtwn != edgbtwn) == 0, 'Difference between old and new find_between'
+
         # edgbtwn is a 3 element array that determines what is between two adjacent left edges
         # edgbtwn[0] is the next right order along, from left order lval
         # edgbtwn[1] is only !=-1 when there's an order overlap.
@@ -1417,7 +1806,14 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
     else:
         lvp = (arutils.func_val(lcoeff[:, lval-1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)
-        edgbtwn = arcytrace.find_between(edgearr, lvp, lv, -1)
+        t = time.clock()
+        _edgbtwn = arcytrace.find_between(edgearr, lvp, lv, -1)
+        print('Old find_between: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        edgbtwn = new_find_between(edgearr, lvp, lv, -1)
+        assert np.sum(_edgbtwn != edgbtwn) == 0, 'Difference between old and new find_between'
+        print('New find_between: {0} seconds'.format(time.clock() - t))
+
         if edgbtwn[0] == -1 and edgbtwn[1] == -1:
             rsub = edgbtwn[2]-(lval-1)  # There's an order overlap
         elif edgbtwn[1] == -1:  # No overlap
@@ -1733,16 +2129,37 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         loord = hiord
         hiord = nxord
         nxord = phys_to_pix(extrap_cent[:,-i], locations, 1)
-        minarrL = arcytrace.minbetween(binarr, loord, hiord)  # Minimum counts between loord and hiord
-        minarrR = arcytrace.minbetween(binarr, hiord, nxord)
+
+        # Minimum counts between loord and hiord
+        print('calling minbetween')
+        t = time.clock()
+        _minarrL = arcytrace.minbetween(binarr, loord, hiord)
+        _minarrR = arcytrace.minbetween(binarr, hiord, nxord)
+        print('Old minbetween: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        minarrL = new_minbetween(binarr, loord, hiord)
+        minarrR = new_minbetween(binarr, hiord, nxord)
+        print('New minbetween: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_minarrL != minarrL) == 0, \
+                'Difference between old and new minbetween, minarrL'
+        assert np.sum(_minarrR != minarrR) == 0, \
+                'Difference between old and new minbetween, minarrR'
+
         minarr = 0.5*(minarrL+minarrR)
         srchz = np.abs(extfit[:,-i]-extfit[:,-i-1])/3.0
         lopos = phys_to_pix(extfit[:,-i]-srchz, locations, 1)  # The pixel indices for the bottom of the search window
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,-i])))
         diffarr = np.round(extrap_diff[:,-i]).astype(np.int)
+
         print('calling find_shift')
-        exit()
-        shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
+        t = time.clock()
+        _shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
+        print('Old find_shift: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        shift = new_find_shift(binarr, minarr, lopos, diffarr, numsrch)
+        print('New find_shift: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_shift != shift) == 0, 'Difference between old and new find_shift, shift'
+
         relshift = np.mean(shift+extrap_diff[:,-i]/2-srchz)
         if shift == -1:
             msgs.info("  Refining order {0:d}: NO relative shift applied".format(int(orders[-i])))
@@ -1764,14 +2181,30 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
     while i > 0:
         hiord = loord
         loord = phys_to_pix(extfit[:,i], locations, 1)
-        minarr = arcytrace.minbetween(binarr,loord, hiord)
+
+        print('calling minbetween')
+        t = time.clock()
+        _minarr = arcytrace.minbetween(binarr,loord, hiord)
+        print('Old minbetween: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        minarr = new_minbetween(binarr,loord, hiord)
+        print('New minbetween: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_minarr != minarr) == 0, 'Difference between old and new minbetween, minarr'
+
         srchz = np.abs(extfit[:,i]-extfit[:,i-1])/3.0
         lopos = phys_to_pix(extfit[:,i-1]-srchz, locations, 1)
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,i-1])))
         diffarr = np.round(extrap_diff[:,i-1]).astype(np.int)
+
         print('calling find_shift')
-        exit()
-        shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
+        t = time.clock()
+        _shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
+        print('Old find_shift: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        shift = new_find_shift(binarr, minarr, lopos, diffarr, numsrch)
+        print('New find_shift: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_shift != shift) == 0, 'Difference between old and new find_shift, shift'
+
         relshift = np.mean(shift+extrap_diff[:,i-1]/2-srchz)
         if shift == -1:
             msgs.info("  Refining order {0:d}: NO relative shift applied".format(int(orders[i-1])))
@@ -2372,8 +2805,17 @@ def echelle_tilt(slf, msarc, det, pcadesc="PCA trace of the spectral tilts", mas
             tilts = np.zeros_like(slf._lordloc)
 
     # Generate tilts image
-    tiltsimg = arcytrace.tilts_image(tilts, slf._lordloc[det-1], slf._rordloc[det-1],
+    print('calling tilts_image')
+    t = time.clock()
+    _tiltsimg = arcytrace.tilts_image(tilts, slf._lordloc[det-1], slf._rordloc[det-1],
                                      settings.argflag['trace']['slits']['pad'], msarc.shape[1])
+    print('Old tilts_image: {0} seconds'.format(time.clock() - t))
+    t = time.clock()
+    tiltsimg = new_tilts_image(tilts, slf._lordloc[det-1], slf._rordloc[det-1],
+                                settings.argflag['trace']['slits']['pad'], msarc.shape[1])
+    print('New tilts_image: {0} seconds'.format(time.clock() - t))
+    assert np.sum(_tiltsimg != tiltsimg) == 0, 'Difference between old and new tilts_image'
+
     return tiltsimg, satmask, outpar
 
 
@@ -2716,10 +3158,40 @@ def get_censpec(slf, frame, det, gen_satmask=False):
     ordwid = 0.5*np.abs(slf._lordloc[det-1]-slf._rordloc[det-1])
     if gen_satmask:
         msgs.info("Generating a mask of arc line saturation streaks")
-        satmask = arcyarc.saturation_mask(frame, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+        t = time.clock()
+        _satmask = arcyarc.saturation_mask(frame,
+                            settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+        print('Old saturation_mask: {0} seconds'.format(time.clock() - t))
+        satmask = ararc.new_saturation_mask(frame,
+                            settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+        print('New saturation_mask: {0} seconds'.format(time.clock() - t))
+        # Allow for minor differences
+        if np.sum(_satmask != satmask) > 0.1*np.prod(satmask.shape):
+            plt.imshow(_satmask, origin='lower', interpolation='nearest', aspect='auto')
+            plt.colorbar()
+            plt.show()
+            plt.imshow(satmask, origin='lower', interpolation='nearest', aspect='auto')
+            plt.colorbar()
+            plt.show()
+            plt.imshow(_satmask-satmask, origin='lower', interpolation='nearest', aspect='auto')
+            plt.colorbar()
+            plt.show()
+
+        assert np.sum(_satmask != satmask) < 0.1*np.prod(satmask.shape), \
+                    'Old and new saturation_mask are too different'
+
         print('calling order saturation')
-        exit()
-        satsnd = arcyarc.order_saturation(satmask, (ordcen+0.5).astype(np.int), (ordwid+0.5).astype(np.int))
+        t = time.clock()
+        _satsnd = arcyarc.order_saturation(satmask, (ordcen+0.5).astype(int),
+                                          (ordwid+0.5).astype(int))
+        print('Old order_saturation: {0} seconds'.format(time.clock() - t))
+        t = time.clock()
+        satsnd = ararc.new_order_saturation(satmask, (ordcen+0.5).astype(int),
+                                             (ordwid+0.5).astype(int))
+        print('New order_saturation: {0} seconds'.format(time.clock() - t))
+        assert np.sum(_satsnd != satsnd) == 0, \
+                    'Difference between old and new order_saturation, satsnd'
+
     # Extract a rough spectrum of the arc in each slit
     msgs.info("Extracting an approximate arc spectrum at the centre of each slit")
     tordcen = None
@@ -2840,14 +3312,18 @@ def phys_to_pix(array, pixlocn, axis):
     """
     from pypit import arcytrace
 
-    if axis == 0:
-        diff = pixlocn[:,0,0]
-    else:
-        diff = pixlocn[0,:,1]
-    if len(np.shape(array)) == 1:
-        pixarr = arcytrace.phys_to_pix(np.array([array]).T, diff).flatten()
-    else:
-        pixarr = arcytrace.phys_to_pix(array, diff)
+    diff = pixlocn[:,0,0] if axis == 0 else pixlocn[0,:,1]
+
+    print('calling phys_to_pix')
+    t = time.clock()
+    _pixarr = arcytrace.phys_to_pix(np.array([array]).T, diff).flatten() \
+                if len(np.shape(array)) == 1 else arcytrace.phys_to_pix(array, diff)
+    print('Old phys_to_pix: {0} seconds'.format(time.clock() - t))
+    t = time.clock()
+    pixarr = new_phys_to_pix(array, diff)
+    print('New phys_to_pix: {0} seconds'.format(time.clock() - t))
+    assert np.sum(_pixarr != pixarr) == 0, 'Difference between old and new phys_to_pix, pixarr'
+
     return pixarr
 
 

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -124,15 +124,15 @@ def assign_slits(binarr, edgearr, ednum=100000, lor=-1):
                 # After pruning, there are no more peaks
                 break
             pks = wpk+2  # Shifted by 2 because of the peak finding algorithm above
-            print('calling find_peak_limits')
-            t = time.clock()
-            _pedges = arcytrace.find_peak_limits(smedgehist, pks)
-            print('Old find_peak_limits: {0} seconds'.format(time.clock() - t))
-            t = time.clock()
+#            print('calling find_peak_limits')
+#            t = time.clock()
+#            _pedges = arcytrace.find_peak_limits(smedgehist, pks)
+#            print('Old find_peak_limits: {0} seconds'.format(time.clock() - t))
+#            t = time.clock()
             pedges = new_find_peak_limits(smedgehist, pks)
-            print('New find_peak_limits: {0} seconds'.format(time.clock() - t))
-            assert np.sum(_pedges != pedges) == 0, \
-                    'Difference between old and new find_peak_limits'
+#            print('New find_peak_limits: {0} seconds'.format(time.clock() - t))
+#            assert np.sum(_pedges != pedges) == 0, \
+#                    'Difference between old and new find_peak_limits'
 
             if np.all(pedges[:, 1]-pedges[:, 0] == 0):
                 # Remaining peaks have no width
@@ -301,7 +301,7 @@ def expand_slits(slf, mstrace, det, ordcen, extord):
     # Calculate the pixel locations of th eorder edges
     pixcen = phys_to_pix(ordcen, slf._pixlocn[det - 1], 1)
     msgs.info("Expanding slit traces to slit edges")
-    exit()
+#    exit()
     mordwid, pordwid = arcytrace.expand_slits(mstrace, pixcen, extord.astype(np.int))
     # Fit a function for the difference between left edge and the centre trace
     ldiff_coeff, ldiff_fit = arutils.polyfitter2d(mordwid, mask=-1,
@@ -540,16 +540,16 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
     msgs.info("Estimating object profiles")
     # Smooth the S/N frame
     smthby, rejhilo = tracepar['smthby'], tracepar['rejhilo']
-    print('calling smooth_x')
-    t = time.clock()
-    _rec_sigframe_bin = arcyutils.smooth_x(rec_sciframe/np.sqrt(rec_varframe), 1.0-rec_crmask,
-                                           smthby, rejhilo, maskval)
-    print('Old smooth_x: {0} seconds'.format(time.clock() - t))
+#    print('calling smooth_x')
+#    t = time.clock()
+#    _rec_sigframe_bin = arcyutils.smooth_x(rec_sciframe/np.sqrt(rec_varframe), 1.0-rec_crmask,
+#                                           smthby, rejhilo, maskval)
+#    print('Old smooth_x: {0} seconds'.format(time.clock() - t))
     tmp = np.ma.MaskedArray(rec_sciframe/np.sqrt(rec_varframe), mask=rec_crmask.astype(bool))
-    # TODO: Add rejection to BoxcarFilter?
-    t = time.clock()
+#    # TODO: Add rejection to BoxcarFilter?
+#    t = time.clock()
     rec_sigframe_bin = BoxcarFilter(smthby).smooth(tmp.T).T
-    print('BoxcarFilter: {0} seconds'.format(time.clock() - t))
+#    print('BoxcarFilter: {0} seconds'.format(time.clock() - t))
 #    t = time.clock()
 #    rec_sigframe_bin = new_smooth_x(rec_sciframe/np.sqrt(rec_varframe), 1.0-rec_crmask, smthby,
 #                                    rejhilo, maskval)
@@ -624,13 +624,13 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
         trcprof2 = np.mean(rec_sciframe, axis=0)
         objl, objr, bckl, bckr = find_obj_minima(trcprof2, triml=triml, trimr=trimr, nsmooth=nsmooth)
     elif settings.argflag['trace']['object']['find'] == 'standard':
-        print('calling find_objects')
-        t = time.clock()
-        _objl, _objr, _bckl, _bckr = arcytrace.find_objects(trcprof, bgreg, mad)
-        print('Old find_objects: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling find_objects')
+#        t = time.clock()
+#        _objl, _objr, _bckl, _bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+#        print('Old find_objects: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
-        print('New find_objects: {0} seconds'.format(time.clock() - t))
+#        print('New find_objects: {0} seconds'.format(time.clock() - t))
 #        print('objl:', objl)
 #        print('_objl:', _objl)
 #        print('objr:', objr)
@@ -639,10 +639,10 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
 #        print(_objr.shape, objr.shape)
 #        print(np.sum(_objl != objl))
 #        print(np.sum(_objr != objr))
-        assert np.sum(_objl != objl) == 0, 'Difference between old and new find_objects, objl'
-        assert np.sum(_objr != objr) == 0, 'Difference between old and new find_objects, objr'
-        assert np.sum(_bckl != bckl) == 0, 'Difference between old and new find_objects, bckl'
-        assert np.sum(_bckr != bckr) == 0, 'Difference between old and new find_objects, bckr'
+#        assert np.sum(_objl != objl) == 0, 'Difference between old and new find_objects, objl'
+#        assert np.sum(_objr != objr) == 0, 'Difference between old and new find_objects, objr'
+#        assert np.sum(_bckl != bckl) == 0, 'Difference between old and new find_objects, bckl'
+#        assert np.sum(_bckr != bckr) == 0, 'Difference between old and new find_objects, bckr'
 #        objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
 
     else:
@@ -1389,23 +1389,23 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
     # Assign a number to each of the edges
     msgs.info("Matching slit edges")
 
-    _edgearr = edgearr.copy()
-    t = time.clock()
-    _lcnt, _rcnt = arcytrace.match_edges(_edgearr, ednum)
-    print('Old match_edges: {0} seconds'.format(time.clock() - t))
+#    _edgearr = edgearr.copy()
+#    t = time.clock()
+#    _lcnt, _rcnt = arcytrace.match_edges(_edgearr, ednum)
+#    print('Old match_edges: {0} seconds'.format(time.clock() - t))
     __edgearr = edgearr.copy()
-    t = time.clock()
+#    t = time.clock()
     lcnt, rcnt = new_match_edges(__edgearr, ednum)
-    print('New match_edges: {0} seconds'.format(time.clock() - t))
+#    print('New match_edges: {0} seconds'.format(time.clock() - t))
 #    print(lcnt, _lcnt, rcnt, _rcnt)
 #    print(np.sum(__edgearr != _edgearr))
 #    plt.imshow(_edgearr, origin='lower', interpolation='nearest', aspect='auto')
 #    plt.show()
 #    plt.imshow(__edgearr, origin='lower', interpolation='nearest', aspect='auto')
 #    plt.show()
-    assert np.sum(_lcnt != lcnt) == 0, 'Difference between old and new match_edges, lcnt'
-    assert np.sum(_rcnt != rcnt) == 0, 'Difference between old and new match_edges, rcnt'
-    assert np.sum(__edgearr != _edgearr) == 0, 'Difference between old and new match_edges, edgearr'
+#    assert np.sum(_lcnt != lcnt) == 0, 'Difference between old and new match_edges, lcnt'
+#    assert np.sum(_rcnt != rcnt) == 0, 'Difference between old and new match_edges, rcnt'
+#    assert np.sum(__edgearr != _edgearr) == 0, 'Difference between old and new match_edges, edgearr'
     edgearr = __edgearr
 
     if lcnt >= ednum or rcnt >= ednum:
@@ -1466,8 +1466,8 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
         assign_slits(binarr, edgearrcp, lor=+1)
     if settings.argflag['trace']['slits']['maxgap'] is not None:
         vals = np.sort(np.unique(edgearrcp[np.where(edgearrcp != 0)]))
-        print('calling close_edges')
-        exit()
+#        print('calling close_edges')
+#        exit()
         hasedge = arcytrace.close_edges(edgearrcp, vals, int(settings.argflag['trace']['slits']['maxgap']))
         # Find all duplicate edges
         edgedup = vals[np.where(hasedge == 1)]
@@ -1552,14 +1552,14 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
                 wvla = np.unique(edgearr[wdup][wdda])
                 wvlb = np.unique(edgearr[wdup][wddb])
                 # Now generate the dual edge
-                print('calling dual_edge')
-                exit()
+#                print('calling dual_edge')
+#                exit()
                 arcytrace.dual_edge(edgearr, edgearrcp, wdup[0], wdup[1], wvla, wvlb, shadj,
                                     int(settings.argflag['trace']['slits']['maxgap']), edgedup[jj])
         # Now introduce new edge locations
         vals = np.sort(np.unique(edgearrcp[np.where(edgearrcp != 0)]))
-        print('calling close_slits')
-        exit()
+#        print('calling close_slits')
+#        exit()
         edgearrcp = arcytrace.close_slits(binarr, edgearrcp, vals, int(settings.argflag['trace']['slits']['maxgap']))
     # Update edgearr
     edgearr = edgearrcp.copy()
@@ -1623,23 +1623,23 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
         msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0])))
         fracpix = int(settings.argflag['trace']['slits']['fracignore']*edgearr.shape[0])
 
-        print('calling ignore_orders')
-        t = time.clock()
-        _edgearr = edgearr.copy()
-        _lnc, _lxc, _rnc, _rxc, _ldarr, _rdarr = arcytrace.ignore_orders(_edgearr, fracpix, lmin, lmax, rmin, rmax)
-        print('Old ignore_orders: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling ignore_orders')
+#        t = time.clock()
+#        _edgearr = edgearr.copy()
+#        _lnc, _lxc, _rnc, _rxc, _ldarr, _rdarr = arcytrace.ignore_orders(_edgearr, fracpix, lmin, lmax, rmin, rmax)
+#        print('Old ignore_orders: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         __edgearr = edgearr.copy()
         lnc, lxc, rnc, rxc, ldarr, rdarr = new_ignore_orders(__edgearr, fracpix, lmin, lmax, rmin,
                                                              rmax)
-        print('New ignore_orders: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_lnc != lnc) == 0, 'Difference between old and new ignore_orders, lnc'
-        assert np.sum(_lxc != lxc) == 0, 'Difference between old and new ignore_orders, lxc'
-        assert np.sum(_rnc != rnc) == 0, 'Difference between old and new ignore_orders, rnc'
-        assert np.sum(_rxc != rxc) == 0, 'Difference between old and new ignore_orders, rxc'
-        assert np.sum(_ldarr != ldarr) == 0, 'Difference between old and new ignore_orders, ldarr'
-        assert np.sum(_rdarr != rdarr) == 0, 'Difference between old and new ignore_orders, rdarr'
-        assert np.sum(__edgearr != _edgearr) == 0, 'Difference between old and new ignore_orders, edgearr'
+#        print('New ignore_orders: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_lnc != lnc) == 0, 'Difference between old and new ignore_orders, lnc'
+#        assert np.sum(_lxc != lxc) == 0, 'Difference between old and new ignore_orders, lxc'
+#        assert np.sum(_rnc != rnc) == 0, 'Difference between old and new ignore_orders, rnc'
+#        assert np.sum(_rxc != rxc) == 0, 'Difference between old and new ignore_orders, rxc'
+#        assert np.sum(_ldarr != ldarr) == 0, 'Difference between old and new ignore_orders, ldarr'
+#        assert np.sum(_rdarr != rdarr) == 0, 'Difference between old and new ignore_orders, rdarr'
+#        assert np.sum(__edgearr != _edgearr) == 0, 'Difference between old and new ignore_orders, edgearr'
 
         edgearr = __edgearr
 
@@ -1785,13 +1785,13 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
     if mnvalp > mnvalm:
         lvp = (arutils.func_val(lcoeff[:, lval+1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)
-        t = time.clock()
-        _edgbtwn = arcytrace.find_between(edgearr, lv, lvp, 1)
-        print('Old find_between: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        t = time.clock()
+#        _edgbtwn = arcytrace.find_between(edgearr, lv, lvp, 1)
+#        print('Old find_between: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         edgbtwn = new_find_between(edgearr, lv, lvp, 1)
-        print('New find_between: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_edgbtwn != edgbtwn) == 0, 'Difference between old and new find_between'
+#        print('New find_between: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_edgbtwn != edgbtwn) == 0, 'Difference between old and new find_between'
 
         # edgbtwn is a 3 element array that determines what is between two adjacent left edges
         # edgbtwn[0] is the next right order along, from left order lval
@@ -1806,13 +1806,13 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
     else:
         lvp = (arutils.func_val(lcoeff[:, lval-1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)
-        t = time.clock()
-        _edgbtwn = arcytrace.find_between(edgearr, lvp, lv, -1)
-        print('Old find_between: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        t = time.clock()
+#        _edgbtwn = arcytrace.find_between(edgearr, lvp, lv, -1)
+#        print('Old find_between: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         edgbtwn = new_find_between(edgearr, lvp, lv, -1)
-        assert np.sum(_edgbtwn != edgbtwn) == 0, 'Difference between old and new find_between'
-        print('New find_between: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_edgbtwn != edgbtwn) == 0, 'Difference between old and new find_between'
+#        print('New find_between: {0} seconds'.format(time.clock() - t))
 
         if edgbtwn[0] == -1 and edgbtwn[1] == -1:
             rsub = edgbtwn[2]-(lval-1)  # There's an order overlap
@@ -2131,19 +2131,19 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         nxord = phys_to_pix(extrap_cent[:,-i], locations, 1)
 
         # Minimum counts between loord and hiord
-        print('calling minbetween')
-        t = time.clock()
-        _minarrL = arcytrace.minbetween(binarr, loord, hiord)
-        _minarrR = arcytrace.minbetween(binarr, hiord, nxord)
-        print('Old minbetween: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling minbetween')
+#        t = time.clock()
+#        _minarrL = arcytrace.minbetween(binarr, loord, hiord)
+#        _minarrR = arcytrace.minbetween(binarr, hiord, nxord)
+#        print('Old minbetween: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         minarrL = new_minbetween(binarr, loord, hiord)
         minarrR = new_minbetween(binarr, hiord, nxord)
-        print('New minbetween: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_minarrL != minarrL) == 0, \
-                'Difference between old and new minbetween, minarrL'
-        assert np.sum(_minarrR != minarrR) == 0, \
-                'Difference between old and new minbetween, minarrR'
+#        print('New minbetween: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_minarrL != minarrL) == 0, \
+#                'Difference between old and new minbetween, minarrL'
+#        assert np.sum(_minarrR != minarrR) == 0, \
+#                'Difference between old and new minbetween, minarrR'
 
         minarr = 0.5*(minarrL+minarrR)
         srchz = np.abs(extfit[:,-i]-extfit[:,-i-1])/3.0
@@ -2151,14 +2151,14 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,-i])))
         diffarr = np.round(extrap_diff[:,-i]).astype(np.int)
 
-        print('calling find_shift')
-        t = time.clock()
-        _shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
-        print('Old find_shift: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling find_shift')
+#        t = time.clock()
+#        _shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
+#        print('Old find_shift: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         shift = new_find_shift(binarr, minarr, lopos, diffarr, numsrch)
-        print('New find_shift: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_shift != shift) == 0, 'Difference between old and new find_shift, shift'
+#        print('New find_shift: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_shift != shift) == 0, 'Difference between old and new find_shift, shift'
 
         relshift = np.mean(shift+extrap_diff[:,-i]/2-srchz)
         if shift == -1:
@@ -2182,28 +2182,28 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         hiord = loord
         loord = phys_to_pix(extfit[:,i], locations, 1)
 
-        print('calling minbetween')
-        t = time.clock()
-        _minarr = arcytrace.minbetween(binarr,loord, hiord)
-        print('Old minbetween: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling minbetween')
+#        t = time.clock()
+#        _minarr = arcytrace.minbetween(binarr,loord, hiord)
+#        print('Old minbetween: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         minarr = new_minbetween(binarr,loord, hiord)
-        print('New minbetween: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_minarr != minarr) == 0, 'Difference between old and new minbetween, minarr'
+#        print('New minbetween: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_minarr != minarr) == 0, 'Difference between old and new minbetween, minarr'
 
         srchz = np.abs(extfit[:,i]-extfit[:,i-1])/3.0
         lopos = phys_to_pix(extfit[:,i-1]-srchz, locations, 1)
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,i-1])))
         diffarr = np.round(extrap_diff[:,i-1]).astype(np.int)
 
-        print('calling find_shift')
-        t = time.clock()
-        _shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
-        print('Old find_shift: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling find_shift')
+#        t = time.clock()
+#        _shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
+#        print('Old find_shift: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         shift = new_find_shift(binarr, minarr, lopos, diffarr, numsrch)
-        print('New find_shift: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_shift != shift) == 0, 'Difference between old and new find_shift, shift'
+#        print('New find_shift: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_shift != shift) == 0, 'Difference between old and new find_shift, shift'
 
         relshift = np.mean(shift+extrap_diff[:,i-1]/2-srchz)
         if shift == -1:
@@ -2805,16 +2805,16 @@ def echelle_tilt(slf, msarc, det, pcadesc="PCA trace of the spectral tilts", mas
             tilts = np.zeros_like(slf._lordloc)
 
     # Generate tilts image
-    print('calling tilts_image')
-    t = time.clock()
-    _tiltsimg = arcytrace.tilts_image(tilts, slf._lordloc[det-1], slf._rordloc[det-1],
-                                     settings.argflag['trace']['slits']['pad'], msarc.shape[1])
-    print('Old tilts_image: {0} seconds'.format(time.clock() - t))
-    t = time.clock()
+#    print('calling tilts_image')
+#    t = time.clock()
+#    _tiltsimg = arcytrace.tilts_image(tilts, slf._lordloc[det-1], slf._rordloc[det-1],
+#                                     settings.argflag['trace']['slits']['pad'], msarc.shape[1])
+#    print('Old tilts_image: {0} seconds'.format(time.clock() - t))
+#    t = time.clock()
     tiltsimg = new_tilts_image(tilts, slf._lordloc[det-1], slf._rordloc[det-1],
                                 settings.argflag['trace']['slits']['pad'], msarc.shape[1])
-    print('New tilts_image: {0} seconds'.format(time.clock() - t))
-    assert np.sum(_tiltsimg != tiltsimg) == 0, 'Difference between old and new tilts_image'
+#    print('New tilts_image: {0} seconds'.format(time.clock() - t))
+#    assert np.sum(_tiltsimg != tiltsimg) == 0, 'Difference between old and new tilts_image'
 
     return tiltsimg, satmask, outpar
 
@@ -3158,39 +3158,39 @@ def get_censpec(slf, frame, det, gen_satmask=False):
     ordwid = 0.5*np.abs(slf._lordloc[det-1]-slf._rordloc[det-1])
     if gen_satmask:
         msgs.info("Generating a mask of arc line saturation streaks")
-        t = time.clock()
-        _satmask = arcyarc.saturation_mask(frame,
-                            settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
-        print('Old saturation_mask: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
+#        _satmask = arcyarc.saturation_mask(frame,
+#                            settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+#        print('Old saturation_mask: {0} seconds'.format(time.clock() - t))
         satmask = ararc.new_saturation_mask(frame,
                             settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
-        print('New saturation_mask: {0} seconds'.format(time.clock() - t))
-        # Allow for minor differences
-        if np.sum(_satmask != satmask) > 0.1*np.prod(satmask.shape):
-            plt.imshow(_satmask, origin='lower', interpolation='nearest', aspect='auto')
-            plt.colorbar()
-            plt.show()
-            plt.imshow(satmask, origin='lower', interpolation='nearest', aspect='auto')
-            plt.colorbar()
-            plt.show()
-            plt.imshow(_satmask-satmask, origin='lower', interpolation='nearest', aspect='auto')
-            plt.colorbar()
-            plt.show()
+#        print('New saturation_mask: {0} seconds'.format(time.clock() - t))
+#        # Allow for minor differences
+#        if np.sum(_satmask != satmask) > 0.1*np.prod(satmask.shape):
+#            plt.imshow(_satmask, origin='lower', interpolation='nearest', aspect='auto')
+#            plt.colorbar()
+#            plt.show()
+#            plt.imshow(satmask, origin='lower', interpolation='nearest', aspect='auto')
+#            plt.colorbar()
+#            plt.show()
+#            plt.imshow(_satmask-satmask, origin='lower', interpolation='nearest', aspect='auto')
+#            plt.colorbar()
+#            plt.show()
+#
+#        assert np.sum(_satmask != satmask) < 0.1*np.prod(satmask.shape), \
+#                    'Old and new saturation_mask are too different'
 
-        assert np.sum(_satmask != satmask) < 0.1*np.prod(satmask.shape), \
-                    'Old and new saturation_mask are too different'
-
-        print('calling order saturation')
-        t = time.clock()
-        _satsnd = arcyarc.order_saturation(satmask, (ordcen+0.5).astype(int),
-                                          (ordwid+0.5).astype(int))
-        print('Old order_saturation: {0} seconds'.format(time.clock() - t))
-        t = time.clock()
+#        print('calling order saturation')
+#        t = time.clock()
+#        _satsnd = arcyarc.order_saturation(satmask, (ordcen+0.5).astype(int),
+#                                          (ordwid+0.5).astype(int))
+#        print('Old order_saturation: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
         satsnd = ararc.new_order_saturation(satmask, (ordcen+0.5).astype(int),
                                              (ordwid+0.5).astype(int))
-        print('New order_saturation: {0} seconds'.format(time.clock() - t))
-        assert np.sum(_satsnd != satsnd) == 0, \
-                    'Difference between old and new order_saturation, satsnd'
+#        print('New order_saturation: {0} seconds'.format(time.clock() - t))
+#        assert np.sum(_satsnd != satsnd) == 0, \
+#                    'Difference between old and new order_saturation, satsnd'
 
     # Extract a rough spectrum of the arc in each slit
     msgs.info("Extracting an approximate arc spectrum at the centre of each slit")
@@ -3314,15 +3314,15 @@ def phys_to_pix(array, pixlocn, axis):
 
     diff = pixlocn[:,0,0] if axis == 0 else pixlocn[0,:,1]
 
-    print('calling phys_to_pix')
-    t = time.clock()
-    _pixarr = arcytrace.phys_to_pix(np.array([array]).T, diff).flatten() \
-                if len(np.shape(array)) == 1 else arcytrace.phys_to_pix(array, diff)
-    print('Old phys_to_pix: {0} seconds'.format(time.clock() - t))
-    t = time.clock()
+#    print('calling phys_to_pix')
+#    t = time.clock()
+#    _pixarr = arcytrace.phys_to_pix(np.array([array]).T, diff).flatten() \
+#                if len(np.shape(array)) == 1 else arcytrace.phys_to_pix(array, diff)
+#    print('Old phys_to_pix: {0} seconds'.format(time.clock() - t))
+#    t = time.clock()
     pixarr = new_phys_to_pix(array, diff)
-    print('New phys_to_pix: {0} seconds'.format(time.clock() - t))
-    assert np.sum(_pixarr != pixarr) == 0, 'Difference between old and new phys_to_pix, pixarr'
+#    print('New phys_to_pix: {0} seconds'.format(time.clock() - t))
+#    assert np.sum(_pixarr != pixarr) == 0, 'Difference between old and new phys_to_pix, pixarr'
 
     return pixarr
 

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -1,5 +1,6 @@
 from __future__ import (print_function, absolute_import, division, unicode_literals)
 
+import time
 import numpy as np
 import copy
 from pypit import arqa
@@ -121,7 +122,17 @@ def assign_slits(binarr, edgearr, ednum=100000, lor=-1):
                 # After pruning, there are no more peaks
                 break
             pks = wpk+2  # Shifted by 2 because of the peak finding algorithm above
+            print('calling find_peak_limits')
+
+            t = time.clock()
             pedges = arcytrace.find_peak_limits(smedgehist, pks)
+            print('Old find_peak_limits: {0} seconds'.format(time.clock() - t))
+            print(pedges.shape)
+            print(pedges[:,0])
+            t = time.clock()
+            pedges = new_find_peak_limits(smedgehist, pks)
+            print('New find_peak_limits: {0} seconds'.format(time.clock() - t))
+            exit()
             if np.all(pedges[:, 1]-pedges[:, 0] == 0):
                 # Remaining peaks have no width
                 break
@@ -567,7 +578,13 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
         trcprof2 = np.mean(rec_sciframe, axis=0)
         objl, objr, bckl, bckr = find_obj_minima(trcprof2, triml=triml, trimr=trimr, nsmooth=nsmooth)
     elif settings.argflag['trace']['object']['find'] == 'standard':
-        objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+#        print('calling find_objects')
+#        t = time.clock()
+#        objl, objr, bckl, bckr = arcytrace.find_objects(trcprof, bgreg, mad)
+#        print('Old find_objects: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
+        objl, objr, bckl, bckr = new_find_objects(trcprof, bgreg, mad)
+#        print('New find_objects: {0} seconds'.format(time.clock() - t))
     else:
         msgs.error("Bad object identification algorithm!!")
     if msgs._debug['trace_obj']:
@@ -696,6 +713,175 @@ def trace_object(slf, det, sciframe, varframe, crmask, trim=2,
                           root="object_trace", normalize=False)
     # Return
     return tracedict
+
+
+def new_find_objects(profile, bgreg, stddev):
+    """
+    Find significantly detected objects in the profile array
+    For all objects found, the background regions will be defined.
+    """
+    # Input profile must be a vector
+    if len(profile.shape) != 1:
+        raise ValueError('Input profile array must be 1D.')
+    # Get the length of the array
+    sz_x = profile.size
+    # Copy it to a masked array for processing
+    # TODO: Assumes input is NOT a masked array
+    _profile = np.ma.MaskedArray(profile.copy())
+
+    # Peaks are found as having flux at > 5 sigma and background is
+    # where the flux is not greater than 3 sigma
+    gt_5_sigma = profile > 5*stddev
+    not_gt_3_sigma = np.invert(profile > 3*stddev)
+
+    # Define the object centroids array
+    objl = np.zeros(sz_x, dtype=int)
+    objr = np.zeros(sz_x, dtype=int)
+    has_obj = np.zeros(sz_x, dtype=bool)
+
+    obj = 0
+    while np.any(gt_5_sigma & np.invert(_profile.mask)):
+        # Find next maximum flux point
+        imax = np.ma.argmax(_profile)
+        maxv = _profile[imax]
+        # Find the valid source pixels around the peak
+        f = np.arange(sz_x)[np.roll(not_gt_3_sigma, -imax)]
+        objl[obj] = imax-sz_x+f[-1]
+        objr[obj] = f[0]+imax
+        # Mask source pixels and increment for next iteration
+        has_obj[objl[obj]:objr[obj]+1] = True
+        _profile[objl[obj]:objr[obj]+1] = np.ma.masked
+        obj += 1
+
+    # The background is the region away from sources up to the provided
+    # region size.  Starting pixel for the left limit...
+    s = objl[:obj]-bgreg
+    s[s < 0] = 0
+    # ... and ending pixel for the right limit.
+    e = objr[:obj]+1+bgreg
+    e[e > sz_x] = sz_x
+    # Flag the possible background regions
+    bgl = np.zeros((sz_x,obj), dtype=bool)
+    bgr = np.zeros((sz_x,obj), dtype=bool)
+    for i in range(obj):
+        bgl[s[i]:objl[i],i] = True
+        bgr[objl[i]+1:e[i],i] = True
+
+    # Return source region limits and background regions that do not
+    # have sources
+    return objl[:obj], objr[:obj], (bgl & np.invert(has_obj)[:,None]).astype(int), \
+                    (bgr & np.invert(has_obj)[:,None]).astype(int)
+
+
+def new_find_peak_limits(hist, pks):
+    """
+    Find all values between the zeros of hist
+
+    hist and pks are expected to be 1d vectors
+
+    """
+
+    sz_i = pks.shape[0]
+    sz_h = hist.shape[0]
+
+    edges = np.zeros((sz_i,2), dtype=int)
+
+    indx = np.ma.MaskedArray(np.array([np.arange(sz_h)]*sz_i),
+                             mask=(hist == 0)[None,:] | (np.arange(sz_h)[None,:] > pks[:,None]))
+
+    plt.imshow(indx, origin='lower', interpolation='nearest', aspect='auto')
+    plt.show()
+
+    print(hist)
+
+    print(pks[0])
+    print(indx[0,np.invert(indx.mask[0,:])])
+
+    print(pks[1])
+    print(indx[1,np.invert(indx.mask[1,:])])
+    exit()
+    print(sz_i, sz_h)
+    print(pks)
+    print(indx.shape)
+    edges[:,0] = np.ma.amin(indx, axis=1)
+    print(edges[:,0])
+    exit()
+
+    hi_indx = hist_ne_0[None,:] & (np.arange(sz_h)[None,:] > pks[:,None])
+
+
+    for ii in range(0, sz_i):
+
+        indx = (hist != 0) & (np.arange(sz_h) <= pks[ii])
+
+        # Search below the peak
+        lim = pks[ii]
+        while True:
+            if lim < 0:
+                break
+            if hist[lim] == 0:
+                break
+            lim -= 1
+        # Store the limit
+        edges[ii, 0] = lim
+        # Search above the peak
+        lim = pks[ii]
+        while True:
+            if lim > sz_h-1:
+                break
+            if hist[lim] == 0:
+                break
+            lim += 1
+        # Store the limit
+        edges[ii, 1] = lim
+    return edges
+
+
+def new_ignore_orders(edgdet, fracpix, lmin, lmax, rmin, rmax):
+
+    sz_x = edgdet.shape[0]
+    sz_y = edgdet.shape[1]
+
+    lsize = lmax-lmin+1
+    larr = np.zeros((2,lsize), dtype=int)
+    larr[0,:] = sz_x
+
+    rsize = rmax-rmin+1
+    rarr = np.zeros((2,rsize), dtype=int)
+    rarr[0,:] = sz_x
+
+    # TODO: Can I remove the loop?  Or maybe just iterate through the
+    # smallest dimension of edgdet?
+    for x in range(sz_x):
+        indx = edgdet[x,:] < 0
+        if np.any(indx):
+            larr[0,-edgdet[x,indx]-lmin] = np.clip(larr[0,-edgdet[x,indx]-lmin], None, x)
+            larr[1,-edgdet[x,indx]-lmin] = np.clip(larr[1,-edgdet[x,indx]-lmin], x, None)
+        indx = edgdet[x,:] > 0
+        if np.any(indx):
+            rarr[0,edgdet[x,indx]-rmin] = np.clip(rarr[0,edgdet[x,indx]-rmin], None, x)
+            rarr[1,edgdet[x,indx]-rmin] = np.clip(rarr[1,edgdet[x,indx]-rmin], x, None)
+
+    # Go through the array once more to remove pixels that do not cover fracpix
+    edgdet = edgdet.ravel()
+    lt_zero = np.arange(edgdet.size)[edgdet < 0]
+    if len(lt_zero) > 0:
+        edgdet[lt_zero[larr[1,-edgdet[lt_zero]-lmin]-larr[0,-edgdet[lt_zero]-lmin] < fracpix]] = 0
+    gt_zero = np.arange(edgdet.size)[edgdet > 0]
+    if len(gt_zero) > 0:
+        edgdet[gt_zero[rarr[1,edgdet[gt_zero]-rmin]-rarr[0,edgdet[gt_zero]-rmin] < fracpix]] = 0
+    edgdet = edgdet.reshape(sz_x,sz_y)
+
+    # Check if lmin, lmax, rmin, and rmax need to be changed
+    lindx = np.arange(lsize)[larr[1,:]-larr[0,:] > fracpix]
+    lnc = lindx[0]
+    lxc = lsize-1-lindx[-1]
+
+    rindx = np.arange(rsize)[rarr[1,:]-rarr[0,:] > fracpix]
+    rnc = rindx[0]
+    rxc = rsize-1-rindx[-1]
+
+    return lnc, lxc, rnc, rxc, larr, rarr
 
 
 def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
@@ -907,6 +1093,8 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
         assign_slits(binarr, edgearrcp, lor=+1)
     if settings.argflag['trace']['slits']['maxgap'] is not None:
         vals = np.sort(np.unique(edgearrcp[np.where(edgearrcp != 0)]))
+        print('calling close_edges')
+        exit()
         hasedge = arcytrace.close_edges(edgearrcp, vals, int(settings.argflag['trace']['slits']['maxgap']))
         # Find all duplicate edges
         edgedup = vals[np.where(hasedge == 1)]
@@ -991,10 +1179,14 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
                 wvla = np.unique(edgearr[wdup][wdda])
                 wvlb = np.unique(edgearr[wdup][wddb])
                 # Now generate the dual edge
+                print('calling dual_edge')
+                exit()
                 arcytrace.dual_edge(edgearr, edgearrcp, wdup[0], wdup[1], wvla, wvlb, shadj,
                                     int(settings.argflag['trace']['slits']['maxgap']), edgedup[jj])
         # Now introduce new edge locations
         vals = np.sort(np.unique(edgearrcp[np.where(edgearrcp != 0)]))
+        print('calling close_slits')
+        exit()
         edgearrcp = arcytrace.close_slits(binarr, edgearrcp, vals, int(settings.argflag['trace']['slits']['maxgap']))
     # Update edgearr
     edgearr = edgearrcp.copy()
@@ -1057,7 +1249,16 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
         #msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0]*binby)))
         msgs.info("Ignoring any slit that spans < {0:3.2f}x{1:d} pixels on the detector".format(settings.argflag['trace']['slits']['fracignore'], int(edgearr.shape[0])))
         fracpix = int(settings.argflag['trace']['slits']['fracignore']*edgearr.shape[0])
-        lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
+
+#        print('calling ignore_orders')
+#        t = time.clock()
+#        lnc, lxc, rnc, rxc, ldarr, rdarr = arcytrace.ignore_orders(edgearr, fracpix, lmin, lmax, rmin, rmax)
+#        print('Old ignore_orders: {0} seconds'.format(time.clock() - t))
+#        t = time.clock()
+        lnc, lxc, rnc, rxc, ldarr, rdarr = new_ignore_orders(edgearr, fracpix, lmin, lmax, rmin,
+                                                             rmax)
+#        print('New ignore_orders: {0} seconds'.format(time.clock() - t))
+
         lmin += lnc
         rmin += rnc
         lmax -= lxc
@@ -1200,6 +1401,8 @@ def trace_slits(slf, mstrace, det, pcadesc="", maskBadRows=False, min_sqm=30.):
     if mnvalp > mnvalm:
         lvp = (arutils.func_val(lcoeff[:, lval+1-lmin], xv, settings.argflag['trace']['slits']['function'],
                                 minv=minvf, maxv=maxvf)+0.5).astype(np.int)
+        print('calling find_between')
+        exit()
         edgbtwn = arcytrace.find_between(edgearr, lv, lvp, 1)
         # edgbtwn is a 3 element array that determines what is between two adjacent left edges
         # edgbtwn[0] is the next right order along, from left order lval
@@ -1537,6 +1740,8 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         lopos = phys_to_pix(extfit[:,-i]-srchz, locations, 1)  # The pixel indices for the bottom of the search window
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,-i])))
         diffarr = np.round(extrap_diff[:,-i]).astype(np.int)
+        print('calling find_shift')
+        exit()
         shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
         relshift = np.mean(shift+extrap_diff[:,-i]/2-srchz)
         if shift == -1:
@@ -1564,6 +1769,8 @@ def refine_traces(binarr, outpar, extrap_cent, extrap_diff, extord, orders,
         lopos = phys_to_pix(extfit[:,i-1]-srchz, locations, 1)
         numsrch = np.int(np.max(np.round(2.0*srchz-extrap_diff[:,i-1])))
         diffarr = np.round(extrap_diff[:,i-1]).astype(np.int)
+        print('calling find_shift')
+        exit()
         shift = arcytrace.find_shift(binarr, minarr, lopos, diffarr, numsrch)
         relshift = np.mean(shift+extrap_diff[:,i-1]/2-srchz)
         if shift == -1:
@@ -2510,6 +2717,8 @@ def get_censpec(slf, frame, det, gen_satmask=False):
     if gen_satmask:
         msgs.info("Generating a mask of arc line saturation streaks")
         satmask = arcyarc.saturation_mask(frame, settings.spect[dnum]['saturation']*settings.spect[dnum]['nonlinear'])
+        print('calling order saturation')
+        exit()
         satsnd = arcyarc.order_saturation(satmask, (ordcen+0.5).astype(np.int), (ordwid+0.5).astype(np.int))
     # Extract a rough spectrum of the arc in each slit
     msgs.info("Extracting an approximate arc spectrum at the centre of each slit")

--- a/pypit/arutils.py
+++ b/pypit/arutils.py
@@ -730,8 +730,6 @@ def gauss_lsqfit(x,y,pcen):
     if np.any(y<0.0):
         return [0.0, 0.0, 0.0], True
     # Obtain a quick first guess at the parameters
-    print('calling fit_gauss')
-    exit()
     ampl, cent, sigm, good = arcyarc.fit_gauss(x, y, np.zeros(3,dtype=np.float), 0, x.size, float(pcen))
     if good == 0:
         return [0.0, 0.0, 0.0], True
@@ -757,8 +755,6 @@ def gauss_fit(x, y, pcen):
             return [0.0, 0.0, 0.0], True
         if x.size <= 3:
             return [0.0, 0.0, 0.0], True
-        print('calling fit_gauss')
-        exit()
         ampl, cent, sigm, good = arcyarc.fit_gauss(x, y, np.zeros(3,dtype=np.float), 0, x.size, float(pcen))
         if good == 0:
             return [0.0, 0.0, 0.0], True

--- a/pypit/arutils.py
+++ b/pypit/arutils.py
@@ -730,6 +730,8 @@ def gauss_lsqfit(x,y,pcen):
     if np.any(y<0.0):
         return [0.0, 0.0, 0.0], True
     # Obtain a quick first guess at the parameters
+    print('calling fit_gauss')
+    exit()
     ampl, cent, sigm, good = arcyarc.fit_gauss(x, y, np.zeros(3,dtype=np.float), 0, x.size, float(pcen))
     if good == 0:
         return [0.0, 0.0, 0.0], True
@@ -755,6 +757,8 @@ def gauss_fit(x, y, pcen):
             return [0.0, 0.0, 0.0], True
         if x.size <= 3:
             return [0.0, 0.0, 0.0], True
+        print('calling fit_gauss')
+        exit()
         ampl, cent, sigm, good = arcyarc.fit_gauss(x, y, np.zeros(3,dtype=np.float), 0, x.size, float(pcen))
         if good == 0:
             return [0.0, 0.0, 0.0], True

--- a/pypit/filter.py
+++ b/pypit/filter.py
@@ -1,0 +1,553 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+# -*- coding: utf-8 -*-
+"""
+A set of functions used to filter arrays.
+
+*License*:
+    Copyright (c) 2017, SDSS-IV/MaNGA Pipeline Group
+        Licensed under BSD 3-clause license - see LICENSE.rst
+
+*Source location*:
+    $MANGADAP_DIR/python/mangadap/util/filter.py
+
+*Imports and python version compliance*:
+    ::
+
+        from __future__ import division
+        from __future__ import print_function
+        from __future__ import absolute_import
+        from __future__ import unicode_literals
+
+        import sys
+        if sys.version > '3':
+            long = int
+
+        import numpy
+
+*Revision history*:
+    | **26 Jan 2017**: Original implementation by K. Westfall (KBW)
+    | **06 Apr 2017**: Interpolate sigma vectors as well as the smoothed
+        vectors in :class:`BoxcarFilter`.
+    | **21 Dec 2017**: Add weighting functionality to
+        :class:`BoxcarFilter`.
+"""
+
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import sys
+if sys.version > '3':
+    long = int
+
+import warnings
+import numpy
+from scipy import interpolate, sparse
+
+# Debug
+from matplotlib import pyplot
+from matplotlib.ticker import NullFormatter
+
+def high_pass_filter(flux, dw=0, k=None, Dw=None):
+    """
+    Pulled from FIREFLY's hpf() function and edited on 17 Nov 2016.
+
+    Apply a high-pass filter to the input vector.
+
+    """
+
+    n = flux.size
+    _dw = int(dw)
+
+    if k is None and Dw is None:
+        Dw = 100
+        _k = n//Dw
+    elif k is not None and Dw is None:
+        _k = int(k)
+        Dw = n//_k
+    elif k is None and Dw is not None:
+        _k = n//Dw
+    else:
+        raise ValueError('Cannot provide both k and Dw.')
+
+    # PRINT A REPORT
+
+    # Rita's typical inputs for SDSS:
+    # w = 10 # 10
+    # windowsize = 20 # 20
+
+    # My MaNGA inputs:
+    # if w == 0 and windowsize == 0:
+    #     print "HPF parameters not specified: choosing default window (stepsize=40)"
+    #     w = 40
+    #     windowsize = 0
+
+    h           = numpy.fft.fft(flux)
+    h_filtered  = numpy.zeros(n, dtype=complex)
+    window      = numpy.zeros(n)
+    unwindow    = numpy.zeros(n)
+    window[0]   = 1                             # keep F0 for normalisation
+    unwindow[0] = 1
+
+    for i in range(_dw):
+        window[_k+i] = (i+1.0)/_dw
+        window[n-1-(_k+_dw-i)] = (_dw-i)/_dw
+    window[_k+_dw:n-(_k+_dw)] = 1
+
+    unwindow        = 1 - window
+    unwindow[0]     = 1
+    
+    h_filtered      = h * window
+    un_h_filtered   = h * unwindow
+
+    res     = numpy.real(numpy.fft.ifft(h_filtered))
+    unres   = numpy.real(numpy.fft.ifft(un_h_filtered)) 
+    res_out = (1.0+(res-numpy.median(res))/unres) * numpy.median(res) 
+
+    return res_out, window, res, unres
+
+#def off_diagonal_identity(size, win):
+#    r"""
+#    Construct a matrix with ones within a window along the diagonal.
+#
+#    Args:
+#        size (int) : Size for the square matrix; i.e., :math:`N` for the
+#            :math:`N\timesN` matrix.
+#        win (int): Number of ones in each row along the diagonal.
+#
+#    Raises:
+#        ValueError: Raised if the window is larger than 2*size-1.
+#
+#    """
+#    if win > 2*size-1:
+#        raise ValueError('Window too large for matrix size.')
+#    if win == 2*size-1:
+#        return numpy.ones((size,size), dtype=int)
+#    x = numpy.zeros((size,size), dtype=int)#numpy.identity(size).astype(int)
+#    for i in range(1,(win+1)//2):
+#        x[:-i,i:] = x[:-i,i:] + numpy.identity(size-i).astype(int)
+#    x += x.T
+#    if win % 2 != 1:
+#        x[:-i-1,i+1:] = x[:-i-1,i+1:] + numpy.identity(size-i-1).astype(int)
+#    return x + numpy.identity(size).astype(int)
+
+def off_diagonal_identity(size, win, return_sparse=False):
+    r"""
+    Construct a matrix with ones within a window along the diagonal.
+
+    Args:
+        size (int) : Size for the square matrix; i.e., :math:`N` for the
+            :math:`N\timesN` matrix.
+        win (int): Number of ones in each row along the diagonal.
+
+    Raises:
+        ValueError: Raised if the window is larger than 2*size-1.
+
+    """
+    if win > 2*size-1:
+        raise ValueError('Window too large for matrix size.')
+    if win == 2*size-1:
+        return numpy.ones((size,size), dtype=int)
+
+    # Indices of diagonal
+    ii = numpy.arange(size).astype(int)
+
+    # Build the upper triangle
+    i = numpy.empty(0, dtype=int)
+    j = numpy.empty(0, dtype=int)
+    for k in range(1,(win+1)//2):
+        i = numpy.append(i, ii[:size-k])
+        j = numpy.append(j, ii[k:size])
+
+    # Copy to the lower triangle
+    _i = numpy.append(i,j)
+    j = numpy.append(j,i)
+
+    # Add the diagonal
+    i = numpy.append(_i, ii)
+    j = numpy.append(j, ii)
+
+    # Accommodate an even window
+    if win % 2 != 1:
+        i = numpy.append(i, ii[:size-k-1])
+        j = numpy.append(j, ii[k+1:size])
+
+    # Construct and return the array
+    if return_sparse:
+        return sparse.coo_matrix((numpy.ones(len(i), dtype=int),(i,j)), shape=(size,size)).tocsr()
+
+    a = numpy.zeros((size,size), dtype=int)
+    a[i,j] = 1
+    return a
+
+
+def build_smoothing_mask(x, pix_buffer, default=None, mask_x=None):
+    r"""
+    Construct a mask for the provided vector that masks the first and
+    last pix_buffer pixels in the coordinate vector.
+    
+    The mask is instantiated as fully unmasked, unless a default mask is
+    provided.
+    
+    To mask specified ranges in x, provide mask_x with a shape
+    :math:`N_{\rm mask}\times 2` where each mask is defined by the
+    starting and ending value of x to exclude.
+    """
+    # Smooth the ratio of the data to the model
+    if len(x.shape) != 1:
+        raise ValueError('Input must be a vector.')
+    npix = x.size
+    mask = numpy.zeros(npix, dtype=bool) if default is None else default.copy()
+    if mask.size != npix:
+        raise ValueError('Provided default has an incorrect length.')
+    mask[:pix_buffer] = True
+    mask[-pix_buffer:] = True
+    if mask_x is None:
+        return mask
+
+    for m in mask_x:
+        mask |= numpy.logical_and(x > m[0], x < m[1])
+    return mask
+
+
+class BoxcarFilter():
+    def __init__(self, boxcar, lo=None, hi=None, niter=None, y=None, wgt=None, mask=None,
+                 local_sigma=None):
+
+        if boxcar <= 1:
+            raise ValueError('Boxcar must be greater than 1!')
+
+        self.y = None
+        self.wgt = None
+        self.input_mask = None
+        self.output_mask = None
+        self.boxcar = boxcar
+        self.lo_rej = lo
+        self.hi_rej = hi
+        self.nrej = -1 if niter is None else niter
+        self.nvec = None
+        self.npix = None
+        self.local_sigma = False if local_sigma is None else local_sigma
+
+        self.smoothed_wgt = None
+        self.smoothed_n = None
+        self.smoothed_y = None
+        self.sigma_y = None
+        self.rdx_index = None
+
+        if y is not None:
+            self.smooth(y, wgt=wgt, mask=mask, boxcar=boxcar, lo=lo, hi=hi, niter=niter,
+                        local_sigma=local_sigma)
+
+
+    def _assign_par(self, boxcar, lo, hi, niter, local_sigma):
+        if boxcar is not None:
+            self.boxcar = boxcar
+        if lo is not None:
+            self.lo_rej = lo
+        if hi is not None:
+            self.hi_rej = hi
+        if niter is not None:
+            self.nrej = niter
+        if local_sigma is not None:
+            self.local_sigma = local_sigma
+
+
+    def _check_par(self):
+        if self.boxcar <= 1:
+            raise ValueError('Boxcar must be greater than 1!')
+
+        if self.nrej is not None and self.nrej > 0 and self.lo_rej is None and self.hi_rej is None:
+            raise ValueError('Must provide lo or hi if niter provided')
+
+
+    def _reduce_indices(self):
+        indx = numpy.array([numpy.arange(self.npix)-self.boxcar//2,
+                            numpy.arange(self.npix)+self.boxcar//2+1])
+        if self.boxcar % 2 != 1:
+            indx[:self.npix] += 1
+        return indx.T.ravel().clip(0,self.npix-1)
+
+
+    def _apply(self):
+        self.smoothed_n = numpy.add.reduceat(numpy.invert(self.output_mask), self.rdx_index, axis=1,
+                                             dtype=int)[:,::2]
+        self.smoothed_wgt = numpy.add.reduceat(self.input_wgt, self.rdx_index, axis=1,
+                                             dtype=float)[:,::2]
+        self.smoothed_y = numpy.add.reduceat(self.input_wgt*self.y.filled(0.0), self.rdx_index,
+                                             axis=1, dtype=float)[:,::2]
+        smoothed_y2 = numpy.add.reduceat(self.input_wgt*numpy.square(self.y.filled(0.0)),
+                                         self.rdx_index, axis=1, dtype=float)[:,::2]
+
+        self.smoothed_y = numpy.ma.divide(self.smoothed_y, self.smoothed_wgt)
+        self.smoothed_y[self.output_mask | (self.smoothed_n == 0)] = numpy.ma.masked
+
+        self.sigma_y = numpy.ma.sqrt((numpy.ma.divide(smoothed_y2, self.smoothed_wgt)
+                                            - numpy.square(self.smoothed_y))
+                                        * numpy.ma.divide(self.smoothed_n, self.smoothed_n-1)) \
+                        if self.local_sigma else \
+                            numpy.ma.MaskedArray(numpy.array([numpy.std(self.y - self.smoothed_y,
+                                                                        axis=1)]*self.npix).T)
+
+        self.output_mask = numpy.ma.getmaskarray(self.smoothed_y) \
+                                | numpy.ma.getmaskarray(self.sigma_y) 
+        
+        self.smoothed_y[self.output_mask | (self.smoothed_n == 0)] = numpy.ma.masked
+        self.sigma_y[self.output_mask | (self.smoothed_n == 0)] = numpy.ma.masked
+
+        return
+
+        w,h = pyplot.figaspect(1)
+        fig = pyplot.figure(figsize=(1.5*w,1.5*h))
+
+        minf = numpy.amin( numpy.ma.log10(numpy.append(self.y.compressed(), self.smoothed_y.compressed())) )
+        maxf = numpy.amax( numpy.ma.log10(numpy.append(self.y.compressed(), self.smoothed_y.compressed())) )
+
+        mins = numpy.amin(numpy.ma.log10(self.sigma_y).compressed())
+        maxs = numpy.amax(numpy.ma.log10(self.sigma_y).compressed())
+
+        minr = numpy.amin(numpy.ma.log10(numpy.ma.divide(self.y, self.smoothed_y)).compressed())
+        maxr = numpy.amax(numpy.ma.log10(numpy.ma.divide(self.y, self.smoothed_y)).compressed())
+
+        ax = fig.add_axes([0.05, 0.50, 0.45, 0.45])
+        ax.xaxis.set_major_formatter(NullFormatter())
+        ax.imshow(numpy.ma.log10(self.y), origin='lower', interpolation='nearest', vmin=minf,
+                  vmax=maxf, aspect='auto')
+        ax = fig.add_axes([0.50, 0.50, 0.45, 0.45])
+        ax.xaxis.set_major_formatter(NullFormatter())
+        ax.yaxis.set_major_formatter(NullFormatter())
+        ax.imshow(numpy.ma.log10(self.smoothed_y), origin='lower', interpolation='nearest',
+                  vmin=minf, vmax=maxf, aspect='auto')
+        ax = fig.add_axes([0.05, 0.05, 0.45, 0.45])
+        ax.yaxis.set_major_formatter(NullFormatter())
+        ax.imshow(numpy.ma.log10(numpy.ma.divide(self.y,self.smoothed_y)), origin='lower',
+                  interpolation='nearest', aspect='auto', vmin=minr, vmax=maxr)
+        ax = fig.add_axes([0.50, 0.05, 0.45, 0.45])
+        ax.yaxis.set_major_formatter(NullFormatter())
+        ax.imshow(numpy.ma.log10(self.sigma_y), origin='lower', interpolation='nearest',
+                  aspect='auto', vmin=mins, vmax=maxs)
+
+        pyplot.show()
+        exit()
+
+    
+    def _interpolate(self):
+        """
+        Interpolate the smoothed image across the masked regions.
+        Leading and trailing masked regions of each row are set to the
+        first and last unmasked value, respectively.
+
+        interpolate both the smoothed data and the sigma
+
+        """
+        # Boolean arrays with bad pixels (should be the same for both
+        # smoothed_y and sigma_y)
+        badpix = numpy.ma.getmaskarray(self.smoothed_y)
+
+        # Deal with any vectors that are fully masked
+        goodvec = numpy.sum(numpy.invert(badpix), axis=1) > 0
+        ngood = numpy.sum(goodvec)
+        veci = numpy.arange(self.nvec)[goodvec]
+
+        # Find the first and last unflagged pixels in the good vectors
+        pixcoo = numpy.ma.MaskedArray(numpy.array([numpy.arange(self.npix)]*ngood),
+                                      mask=badpix[goodvec,:]).astype(int)
+        mini = numpy.ma.amin(pixcoo, axis=1)
+        maxi = numpy.ma.amax(pixcoo, axis=1)
+
+        # Copy those to the first and last pixels for each row
+        self.smoothed_y[veci,0] = numpy.array([self.smoothed_y[i,m] for i,m in zip(veci, mini)])
+        self.smoothed_y[veci,-1] = numpy.array([self.smoothed_y[i,m] for i,m in zip(veci, maxi)])
+
+        self.sigma_y[veci,0] = numpy.array([self.sigma_y[i,m] for i,m in zip(veci, mini)])
+        self.sigma_y[veci,-1] = numpy.array([self.sigma_y[i,m] for i,m in zip(veci, maxi)])
+
+        # Detach badpix from self.smoothed_y
+        badpix = numpy.ma.getmaskarray(self.smoothed_y).copy()
+
+        # Interpolate the smoothed array
+        x = numpy.ma.MaskedArray(numpy.arange(self.nvec*self.npix), mask=badpix)
+        interpolator = interpolate.interp1d(x.compressed(), self.smoothed_y.compressed(),
+                                            assume_sorted=True, fill_value='extrapolate')
+        self.smoothed_y.ravel()[badpix.ravel()] = interpolator(x.data[badpix.ravel()])
+        self.smoothed_y[numpy.invert(goodvec),:] = 0.0
+
+        # Interpolate the sigma array
+        interpolator = interpolate.interp1d(x.compressed(), self.sigma_y.compressed(),
+                                            assume_sorted=True, fill_value='extrapolate')
+        self.sigma_y.ravel()[badpix.ravel()] = interpolator(x.data[badpix.ravel()])
+        self.sigma_y[numpy.invert(goodvec),:] = 0.0
+
+
+    def smooth(self, y, wgt=None, mask=None, boxcar=None, lo=None, hi=None, niter=None,
+               local_sigma=None):
+        """
+        Smooth a vector or array of vectors by a boxcar with specified
+        rejection.
+        """
+        # Assign and check the binning parameters
+        self._assign_par(boxcar, lo, hi, niter, local_sigma)
+        self._check_par()
+
+        # Check the input vector/array
+        if len(y.shape) > 2:
+            raise ValueError('Can only deal with vectors or matrices.')
+
+        # Set the weighting
+        self.input_wgt = numpy.ones(y.shape, dtype=bool) if wgt is None else wgt
+        if self.input_wgt.shape != y.shape:
+            raise ValueError('Weights shape does not match data.')
+        if isinstance(y, numpy.ma.MaskedArray):
+            self.input_wgt[numpy.ma.getmaskarray(y)] = 0.0
+
+        # Set the mask
+        self.input_mask = numpy.zeros(y.shape, dtype=bool) if mask is None else mask
+        if self.input_mask.shape != y.shape:
+            raise ValueError('Mask shape does not match data.')
+        if isinstance(y, numpy.ma.MaskedArray):
+            self.input_mask |= numpy.ma.getmaskarray(y)
+
+        # Save the input
+        provided_vector = len(y.shape) == 1
+        self.y = numpy.ma.atleast_2d(numpy.ma.MaskedArray(y.copy(), mask=self.input_mask))
+        self.input_wgt = numpy.atleast_2d(self.input_wgt)
+        self.input_mask = numpy.atleast_2d(self.input_mask)
+        self.output_mask = self.input_mask.copy()
+        self.nvec, self.npix = self.y.shape
+
+        # Create the list of reduceat indices
+        self.rdx_index = self._reduce_indices()
+
+        # Get the first iteration of the smoothed vectors
+        self._apply()
+
+        # No rejection iterations requested so return the result
+        if self.lo_rej is None and self.hi_rej is None:
+            self._interpolate()
+            return self.smoothed_y[0,:] if provided_vector else self.smoothed_y
+
+        # Iteratively reject outliers
+        nmasked = numpy.sum(numpy.ma.getmaskarray(self.y))
+        i=0
+        while i > -1:
+            nbad = numpy.sum(self.output_mask)
+            if self.lo_rej is not None:
+                self.output_mask = numpy.logical_or(self.output_mask, self.y.data - self.smoothed_y
+                                                        < (-self.lo_rej*self.sigma_y))
+            if self.hi_rej is not None:
+                self.output_mask = numpy.logical_or(self.output_mask, self.y.data - self.smoothed_y
+                                                        > (self.hi_rej*self.sigma_y))
+            self.y[self.output_mask] = numpy.ma.masked
+            self._apply()
+
+            nmasked = numpy.sum(self.output_mask) - nbad
+#            print('Niter: {0}; Nmasked: {1}'.format(i+1, nmasked))
+
+            i += 1
+            if i == self.nrej or nmasked == 0:
+                break
+
+        self._interpolate()
+        return self.smoothed_y[0,:] if provided_vector else self.smoothed_y
+
+
+    @property
+    def mask(self):
+        return self.output_mask.copy()
+
+
+
+def smooth_masked_vector(x, nsmooth):
+    """
+    Smooth a masked vector by a box of size nsmooth.
+    """
+    n = off_diagonal_identity(x.size, nsmooth)*numpy.invert(numpy.ma.getmaskarray(x))[None,:]
+    nn = numpy.sum(n,axis=1)
+    return numpy.ma.MaskedArray(numpy.dot(n,x.data), mask=numpy.invert(nn>0) | x.mask)/nn
+
+
+def interpolate_masked_vector(y, quiet=True, extrap_with_median=False):
+    """
+    Interpolate over the masked pixels in an input vector using linear
+    interpolation.
+    """
+    x = numpy.arange(y.size)
+    indx = numpy.ma.getmaskarray(y)
+    if numpy.sum(numpy.invert(indx)) < 2:
+        if not quiet:
+            warnings.warn('Input vector has fewer than 2 unmasked values!  Returning zero vector.')
+        return numpy.zeros(y.size, dtype=y.dtype.name)
+    interpolator = interpolate.interp1d(x[numpy.invert(indx)], y[numpy.invert(indx)],
+                                        fill_value='extrapolate')
+    _y = y.data.copy()
+    _y[indx] = interpolator(x[indx])
+
+    if extrap_with_median:
+        med = numpy.median(interpolator.y)
+        m_indx = (x[indx] < interpolator.x[0]) | (x[indx] > interpolator.x[-1])
+        _y[indx][m_indx] = med
+
+    return _y
+
+
+def boxcar_smooth_vector(x, boxcar, mask=None, lo=None, hi=None, niter=None, return_mask=False):
+    """
+    Boxcar smooth an input vector.
+        - Ignores masked pixels.
+        - Allows for iterative positive and negative outliers.
+        - Can return the mask separately from the smoothed vector.
+    """
+    if niter is not None and lo is None and hi is None:
+        raise ValueError('Must provide lo or hi if niter provided')
+
+    _mask = numpy.zeros(x.size, dtype=bool) if mask is None else mask
+    _x = x if isinstance(x, numpy.ma.MaskedArray) else numpy.ma.MaskedArray(x)
+    _x[_mask] = numpy.ma.masked
+
+    sx = interpolate_masked_vector( smooth_masked_vector(_x, boxcar) )
+
+#    pyplot.step(numpy.arange(_x.size), _x.data, where='mid', color='0.3', lw=0.5)
+#    pyplot.step(numpy.arange(_x.size), _x, where='mid', color='k', lw=0.5)
+#    pyplot.plot(numpy.arange(_x.size), sx, color='r', lw=1)
+#    pyplot.show()
+
+    if numpy.all([ x is None for x in [ lo, hi, niter ]]):
+        if return_mask:
+            return sx, numpy.ma.getmaskarray(_x).copy()
+        return sx
+    
+    _niter = -1 if niter is None else niter
+    nrej = numpy.sum(numpy.ma.getmaskarray(_x))
+    i=0
+    while i > -1:
+        sig = numpy.std((_x - sx).compressed())
+        mask = numpy.ma.getmaskarray(_x).copy()
+        if lo is not None:
+            mask = numpy.logical_or(mask, _x.data - sx < -lo*sig)
+        if hi is not None:
+            mask = numpy.logical_or(mask, _x.data - sx > hi*sig)
+        nrej = numpy.sum(mask) - numpy.sum(_x.mask)
+#        print('Niter: {0}; Nrej: {1}'.format(i+1, nrej))
+        _x[mask] = numpy.ma.masked
+        sx = interpolate_masked_vector( smooth_masked_vector(_x, boxcar) )
+
+#        pyplot.step(numpy.arange(_x.size), _x.data, where='mid', color='cyan', lw=0.5)
+#        pyplot.step(numpy.arange(_x.size), _x, where='mid', color='k', lw=0.5)
+#        pyplot.plot(numpy.arange(_x.size), sx, color='r', lw=1)
+#        pyplot.show()
+
+        i += 1
+        if i == _niter or nrej == 0:
+            break
+
+    pyplot.step(numpy.arange(_x.size), _x.data, where='mid', color='cyan', lw=0.5)
+    pyplot.step(numpy.arange(_x.size), _x, where='mid', color='k', lw=0.5)
+    pyplot.plot(numpy.arange(_x.size), sx, color='r', lw=1)
+    pyplot.show()
+
+    if return_mask:
+        return sx, numpy.ma.getmaskarray(_x).copy()
+    return sx
+
+


### PR DESCRIPTION
This follows my initial pull request from my fork.  Here's a summary of what I've done with the cython code so far:

Obsolete with new python functions:
 - arcyarc.pyx
 - arcycomb.pyx
 - arcyproc.pyx
 - arcyutils.pyx

Contains functions that were not rewritten:
 - arcytrace.pyx 
    
Functions called but not touched by pypit_test:
 - arcytrace.close_edges
 - arcytrace.close_slits
 - arcytrace.dual_edge
 - arcytrace.expand_slits

arutils.gauss_lsqfit and arutils.gauss_fit call arcyarc.fit_gauss, but this cython function doesn't exist.

```
cython function             python function                     Check
---------------------------------------------------------------------
arcyarc.order_saturation    ararc.new_order_saturation          exact
arcyarc.saturation_mask     ararc.new_saturation_mask           exact
...                         ararc.determine_saturation_region   ...
...                         ararc.search_for_saturation_edge    ...

arcycomb.masked_limitget    ...                                 ... 
arcycomb.masked_limitset    ...                                 ... 
arcycomb.masked_limitsetarr ...                                 ... 
arcycomb.masked_mean        ...                                 ...
arcycomb.masked_median      ...                                 ...
arcycomb.masked_replace     ...                                 ...
arcycomb.masked_weightmean  ararc.new_masked_weightmean         numerical
arcycomb.maxnonsat          ararc.new_maxnonsat                 (1)
arcycomb.mean               ...                                 ...
arcycomb.median             ...                                 ...
arcycomb.minmax             ...                                 ...

arcyproc.cr_screen          arproc.new_cr_screen                (2)

arcytrace.find_between      artrace.new_find_between            exact
arcytrace.find_objects      artrace.new_find_objects            exact
arcytrace.find_peak_limits  artrace.new_find_peak_limits        exact
arcytrace.find_shift        artrace.new_find_shift              exact
arcytrace.ignore_orders     artrace.new_ignore_orders           exact
arcytrace.limit_yval        artrace.new_limit_yval              exact
arcytrace.locate_order      arproc.new_locate_order             exact
arcytrace.match_edges       artrace.new_match_edges             exact   *
arcytrace.minbetween        artrace.new_minbetween              exact
arcytrace.phys_to_pix       artrace.new_phys_to_pix             exact
arcytrace.tilts_image       artrace.new_tilts_image             exact   *

arcyutils.func2d_fit_val    arextract.new_func2d_fit_val        (3)
arcyutils.grow_masked       arproc.new_grow_masked              exact   *
arcyutils.mean_weight       artrace.new_mean_weight             (4)
arcyutils.order_pixels      arproc.new_order_pixels             exact
arcyutils.smooth_x          artrace.new_smooth_x                (4)
...                         filter.BoxcarFilter                 (4)
```

Checks:
---------
 - 'exact': the consistency check use == to check if the data returned by the cython and python functions are the same.
 - 'numerical': the check is to numerical accuracy.
 - '...': the function was removed and/or replaced with a numpy function.

Notes:
--------

1. There's a bug in the old arcycomb.maxnonsat function.  Because of this, I turned off the exact check of the difference between arcycomb.maxnonsat and arcomb.new_maxnonsat.

2. The arcyproc.cr_screen function can yield nan pixels, but arproc.new_cr_screen does not.  This means there are differences between the returned arrays.  However, in all the cases checked so far, the two arrays are identical for all non-nan pixels.  May need to keep checking this differences.

3. There can be substantial differences between the cython and python versions of func2d_fit_val.  This needs to be tested to see if the results of the new function are satisfactory.

4.  I first recoded arcyutils.smooth_x into artrace.new_smooth_x, but it is very slow (~10 seconds).  I switched to using a function from the MaNGA DAP that I wrote, which is much faster.  Instead of copying over the class (BoxcarFilter), I just copied the entire file for the time being.  There are license differences that we should be aware of.  BoxcarFilter can handle masked arrays, weighting, and rejection. However, it will provide different results from smooth_x.  One main difference is that BoxcarFilter can't do the same rejection procedure that's done in smooth_x (rejection of the highest and lowest n values in the boxcar window).  It does a sigma rejection instead.  We need to test to make sure that the differences between the two algorithms are acceptable and determine what rejection sigma is best when it's needed.

Execution times:
-------------------

For most of these functions, the python equivalent is about an order of magnitude slower than its cython counterpart.  In most cases, this means an execution time that goes from a few hundredths to a few tenths of a second.  The exceptions to this are

artrace.new_match_edges
artrace.new_tilts_image
arproc.new_grow_masked

where the execution time can be more like 100 times slower, going from a few hundredths of a second to ~1 second.  I tried to speed these up, but the specifics of the operations can be difficult to capture without the detailed looping and conditional statements.  We can revisit these when I better understand the limitations of algorithmic changes that might better enable a matrix speed up.

To do in a future PR:
------------------------
 - Ryan says I need DEIMOS data to test `arcytrace.close_edges`, `arcytrace.close_slits`, and `arcytrace.dual_edge`.  I've left these in until I can test replacements.
 - Ryan says I should be able to test `arcytrace.expand_slits` with the `apf_levy.pypit` in the dev suite, but I get an error (issue to be submitted).
 - I've left all the cython code in place, and left the python replacements to have names starting with `new_` just for the time being.  As soon as all of the cython is replaced and the replacements have been tested, I can remove the cython code and dependencies.