### PR TITLE
Hot fixes for artrace

### DIFF
--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -399,8 +399,8 @@ def trace_objbg_image(slf, det, sciframe, slitn, objreg, bgreg, trim=2, triml=No
                                    np.clip(spatdir - robj.reshape(sciframe.shape[0], 1), 0.0, 1.0)
         wrl = np.where(bgreg[1][1:, o] > bgreg[1][:-1, o])[0]
         wrr = np.where(bgreg[1][1:, o] < bgreg[1][:-1, o])[0]
-        if len(wrr) == 0:  # JXP kludge
-            wrr = np.array([len(bgreg[1][1:, o]) - 1]).astype(int)
+        if len(wrr) < len(wrl): # JXP kludge
+            wrr = np.concatenate([wrr, np.array([len(bgreg[1][1:,o])-1]).astype(int)])
         # Background regions to the right of object
         for ii in range(wrl.size):
             lobj = slf._lordloc[det - 1][:, slitn] + triml + wrl[ii]

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -1077,9 +1077,11 @@ def new_find_objects(profile, bgreg, stddev):
     while np.any(gt_5_sigma & np.invert(_profile.mask)):
         # Find next maximum flux point
         imax = np.ma.argmax(_profile)
-        if not gt_5_sigma[imax]:
-            break
-        _profile[imax] = np.ma.masked  # Mask the peak
+        #  IF one is recovering an object mask with *all* pixels triggered,
+        #    then consider uncommenting the next 3 lines -- JXP on 20 Apr 2018
+        #if not gt_5_sigma[imax]:
+        #    break
+        #_profile[imax] = np.ma.masked  # Mask the peak
         # Find the valid source pixels around the peak
         f = np.arange(sz_x)[np.roll(not_gt_3_sigma, -imax)]
         # TODO: the ifs below feel like kludges to match old

--- a/pypit/artrace.py
+++ b/pypit/artrace.py
@@ -389,10 +389,10 @@ def trace_objbg_image(slf, det, sciframe, slitn, objreg, bgreg, trim=2, triml=No
     for o in range(nobj):
         wll = np.where(bgreg[0][1:, o] > bgreg[0][:-1, o])[0]
         wlr = np.where(bgreg[0][1:, o] < bgreg[0][:-1, o])[0]
-        if len(wll) == 0:  # JXP kludge
-            wll = np.array([0]).astype(int)
+        if len(wll) < len(wlr): #< len(wlr): # JXP kludge
+            wll = np.concatenate([np.array([0]).astype(int), wll])
         # Background regions to the left of object
-        for ii in range(wll.size):
+        for ii in range(wlr.size):
             lobj = slf._lordloc[det - 1][:, slitn] + triml + wll[ii]
             robj = slf._lordloc[det - 1][:, slitn] + trimr + wlr[ii]
             rec_bg_img[:, :, o] += np.clip(spatdir - lobj.reshape(sciframe.shape[0], 1), 0.0, 1.0) - \


### PR DESCRIPTION
two fixes (one a semi-kludge) for artrace.py

1. A kludge in the new trace_objbg_image() method. @rcooke-ast -- please advise on how better to fix this.  
1. A few lines missing from the port from Cython of find_objects.  @kbwestfall , take a quick look

