### PR TITLE
Fix coadding of un-fluxed 1D spectra

### DIFF
--- a/doc/coadding.rst
+++ b/doc/coadding.rst
@@ -104,9 +104,12 @@ method, e.g.::
 
     'extract': 'box'
 
-and/or the flux method::
+and/or specify whether the spectrum is fluxed::
 
-    'flux': 'counts'
+    'flux': False
+
+Note that these parameters must be outside of the 'a', 'b', 'c', etc. dicts
+or else they will have no effect.
 
 Cosmic Ray Cleaning
 +++++++++++++++++++

--- a/pypit/scripts/coadd_1dspec.py
+++ b/pypit/scripts/coadd_1dspec.py
@@ -157,7 +157,7 @@ def main(args, unit_test=False, path=''):
                 extensions.append(idx[0]+1)
             else:
                 raise ValueError("Multiple matches to object {:s} in file {:s}".format(iobj, fkey))
-                    
+        
         # Load spectra
         if len(gdfiles) == 0:
             msgs.error("No files match your input criteria")

--- a/pypit/scripts/coadd_1dspec.py
+++ b/pypit/scripts/coadd_1dspec.py
@@ -132,11 +132,10 @@ def main(args, unit_test=False, path=''):
                 #Check if optimal extraction is present in all  objects.
                 # If not, warn the user and set ex_value to 'box'.
                 hdulist = fits.open(fkey)
-                # If we have a fluxed spectrum, look for flam
                 try: #In case the optimal extraction array is a NaN array
-                    if flux_value is True:
+                    if flux_value is True: # If we have a fluxed spectrum, look for flam
                         obj_opt = hdulist[mtch_obj[0]].data['opt_flam']
-                    else:
+                    else: # If not, look for counts
                         obj_opt = hdulist[mtch_obj[0]].data['opt_counts']
                     if any(isnan(obj_opt)):
                         msgs.warn("Object {:s} in file {:s} has a NaN array for optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
@@ -144,9 +143,9 @@ def main(args, unit_test=False, path=''):
                 except KeyError: #In case the array is absent altogether.
                     msgs.warn("Object {:s} in file {:s} doesn't have an optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
                     try:
-                        if flux_value is True:
+                        if flux_value is True: # If we have a fluxed spectrum, look for flam
                             hdulist[mtch_obj[0]].data['box_flam']
-                        else:
+                        else: # If not, look for counts
                             hdulist[mtch_obj[0]].data['box_counts']
                     except KeyError:
                         #In case the boxcar extract is also absent
@@ -157,7 +156,7 @@ def main(args, unit_test=False, path=''):
                 extensions.append(idx[0]+1)
             else:
                 raise ValueError("Multiple matches to object {:s} in file {:s}".format(iobj, fkey))
-        
+
         # Load spectra
         if len(gdfiles) == 0:
             msgs.error("No files match your input criteria")

--- a/pypit/scripts/coadd_1dspec.py
+++ b/pypit/scripts/coadd_1dspec.py
@@ -132,26 +132,26 @@ def main(args, unit_test=False, path=''):
                 #Check if optimal extraction is present in all  objects.
                 # If not, warn the user and set ex_value to 'box'.
                 hdulist = fits.open(fkey)
-                    # If we have a fluxed spectrum, look for flam
-                    try: #In case the optimal extraction array is a NaN array
-                        if flux_value is True:
-                            obj_opt = hdulist[mtch_obj[0]].data['opt_flam']
-                        else:
-                            obj_opt = hdulist[mtch_obj[0]].data['opt_counts']
-                        if any(isnan(obj_opt)):
-                            msgs.warn("Object {:s} in file {:s} has a NaN array for optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
-                            ex_value = 'box'
-                    except KeyError: #In case the array is absent altogether.
-                        msgs.warn("Object {:s} in file {:s} doesn't have an optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
-                        try:
-                            if flux_value is True:
-                                hdulist[mtch_obj[0]].data['box_flam']
-                            else:
-                                hdulist[mtch_obj[0]].data['box_counts']
-                        except KeyError:
-                            #In case the boxcar extract is also absent
-                            msgs.error("Object {:s} in file {:s} doesn't have a boxcar extraction either. Co-addition cannot be performed".format(mtch_obj[0],fkey))
+                # If we have a fluxed spectrum, look for flam
+                try: #In case the optimal extraction array is a NaN array
+                    if flux_value is True:
+                        obj_opt = hdulist[mtch_obj[0]].data['opt_flam']
+                    else:
+                        obj_opt = hdulist[mtch_obj[0]].data['opt_counts']
+                    if any(isnan(obj_opt)):
+                        msgs.warn("Object {:s} in file {:s} has a NaN array for optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
                         ex_value = 'box'
+                except KeyError: #In case the array is absent altogether.
+                    msgs.warn("Object {:s} in file {:s} doesn't have an optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
+                    try:
+                        if flux_value is True:
+                            hdulist[mtch_obj[0]].data['box_flam']
+                        else:
+                            hdulist[mtch_obj[0]].data['box_counts']
+                    except KeyError:
+                        #In case the boxcar extract is also absent
+                        msgs.error("Object {:s} in file {:s} doesn't have a boxcar extraction either. Co-addition cannot be performed".format(mtch_obj[0],fkey))
+                    ex_value = 'box'
                 gdfiles.append(fkey)
                 gdobj += mtch_obj
                 extensions.append(idx[0]+1)

--- a/pypit/scripts/coadd_1dspec.py
+++ b/pypit/scripts/coadd_1dspec.py
@@ -132,25 +132,32 @@ def main(args, unit_test=False, path=''):
                 #Check if optimal extraction is present in all  objects.
                 # If not, warn the user and set ex_value to 'box'.
                 hdulist = fits.open(fkey)
-                try: #In case the optimal extraction array is a NaN array
-                    obj_opt_flam = hdulist[mtch_obj[0]].data['OPT_FLAM']
-                    if any(isnan(obj_opt_flam)):
-                        msgs.warn("Object {:s} in file {:s} has a NaN array for optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
+                    # If we have a fluxed spectrum, look for flam
+                    try: #In case the optimal extraction array is a NaN array
+                        if flux_value is True:
+                            obj_opt = hdulist[mtch_obj[0]].data['opt_flam']
+                        else:
+                            obj_opt = hdulist[mtch_obj[0]].data['opt_counts']
+                        if any(isnan(obj_opt)):
+                            msgs.warn("Object {:s} in file {:s} has a NaN array for optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
+                            ex_value = 'box'
+                    except KeyError: #In case the array is absent altogether.
+                        msgs.warn("Object {:s} in file {:s} doesn't have an optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
+                        try:
+                            if flux_value is True:
+                                hdulist[mtch_obj[0]].data['box_flam']
+                            else:
+                                hdulist[mtch_obj[0]].data['box_counts']
+                        except KeyError:
+                            #In case the boxcar extract is also absent
+                            msgs.error("Object {:s} in file {:s} doesn't have a boxcar extraction either. Co-addition cannot be performed".format(mtch_obj[0],fkey))
                         ex_value = 'box'
-                except KeyError: #In case the array is absent altogether.
-                    msgs.warn("Object {:s} in file {:s} doesn't have an optimal extraction. Boxcar will be used instead.".format(mtch_obj[0],fkey))
-                    try:
-                        hdulist[mtch_obj[0]].data['BOX_FLAM']
-                    except KeyError:
-                        #In case the boxcar extract is also absent
-                        msgs.error("Object {:s} in file {:s} doesn't have a boxcar extraction either. Co-addition cannot be performed".format(mtch_obj[0],fkey))
-                    ex_value = 'box'
                 gdfiles.append(fkey)
                 gdobj += mtch_obj
                 extensions.append(idx[0]+1)
             else:
                 raise ValueError("Multiple matches to object {:s} in file {:s}".format(iobj, fkey))
-
+                    
         # Load spectra
         if len(gdfiles) == 0:
             msgs.error("No files match your input criteria")


### PR DESCRIPTION
Fixed pypit_coadd_1dspec so that it properly handles (i.e. does not crash when presented with) un-fluxed spectra, and updated the documentation to reflect how one would actually do that.