### PR TITLE
Match AB frame

### DIFF
--- a/pypit/arload.py
+++ b/pypit/arload.py
@@ -105,12 +105,15 @@ def load_headers(datlines, settings_spect, settings_argflag):
             kchk = '.'.join(ch.split('.')[1:])
             frhd = whddict['{0:02d}'.format(tfrhd)]
             # JFH changed to in instead of !=
-            if ((settings_spect['check'][ch] in str(headarr[frhd][kchk]).strip()) == False):
-                print(ch, frhd, kchk)
-                print(settings_spect['check'][ch], str(headarr[frhd][kchk]).strip())
-                msgs.warn("The following file:"+msgs.newline()+datlines[i]+msgs.newline()+"is not taken with the settings.{0:s} detector".format(settings_argflag['run']['spectrograph'])+msgs.newline()+"Remove this file, or specify a different settings file.")
-                msgs.warn("Skipping the file..")
-                skip = True
+            try:
+                if ((settings_spect['check'][ch] in str(headarr[frhd][kchk]).strip()) == False):
+                    print(ch, frhd, kchk)
+                    print(settings_spect['check'][ch], str(headarr[frhd][kchk]).strip())
+                    msgs.warn("The following file:"+msgs.newline()+datlines[i]+msgs.newline()+"is not taken with the settings.{0:s} detector".format(settings_argflag['run']['spectrograph'])+msgs.newline()+"Remove this file, or specify a different settings file.")
+                    msgs.warn("Skipping the file..")
+                    skip = True
+            except:
+                debugger.set_trace()
         if skip:
             numfiles -= 1
             continue

--- a/pypit/arload.py
+++ b/pypit/arload.py
@@ -105,15 +105,12 @@ def load_headers(datlines, settings_spect, settings_argflag):
             kchk = '.'.join(ch.split('.')[1:])
             frhd = whddict['{0:02d}'.format(tfrhd)]
             # JFH changed to in instead of !=
-            try:
-                if ((settings_spect['check'][ch] in str(headarr[frhd][kchk]).strip()) == False):
-                    print(ch, frhd, kchk)
-                    print(settings_spect['check'][ch], str(headarr[frhd][kchk]).strip())
-                    msgs.warn("The following file:"+msgs.newline()+datlines[i]+msgs.newline()+"is not taken with the settings.{0:s} detector".format(settings_argflag['run']['spectrograph'])+msgs.newline()+"Remove this file, or specify a different settings file.")
-                    msgs.warn("Skipping the file..")
-                    skip = True
-            except:
-                debugger.set_trace()
+            if ((settings_spect['check'][ch] in str(headarr[frhd][kchk]).strip()) == False):
+                print(ch, frhd, kchk)
+                print(settings_spect['check'][ch], str(headarr[frhd][kchk]).strip())
+                msgs.warn("The following file:"+msgs.newline()+datlines[i]+msgs.newline()+"is not taken with the settings.{0:s} detector".format(settings_argflag['run']['spectrograph'])+msgs.newline()+"Remove this file, or specify a different settings file.")
+                msgs.warn("Skipping the file..")
+                skip = True
         if skip:
             numfiles -= 1
             continue

--- a/pypit/arparse.py
+++ b/pypit/arparse.py
@@ -4511,8 +4511,8 @@ def dummy_settings(pypitdir=None, nfile=10, spectrograph='shane_kast_blue',
 
     """
     # Dummy argflag
-    if spectrograph != 'shane_kast_blue':
-        msgs.error("Only setup for Kast Blue")  # You will need to fuss with scidx
+    if spectrograph not in ['shane_kast_blue', 'keck_nirspec']:
+        msgs.error("Not setup for your instrument")  # You will need to fuss with scidx
     argf = get_argflag_class(("ARMLSD", spectrograph))
     argf.init_param()
     if pypitdir is None:

--- a/pypit/arparse.py
+++ b/pypit/arparse.py
@@ -3020,6 +3020,17 @@ class BaseSpect(BaseFunctions):
         v = key_keyword(v)
         self.update(v)
 
+    def keyword_imagetype(self, v):
+        """ The KOA added keyword that identifies the frame type
+
+        Parameters
+        ----------
+        v : str
+          value of the keyword argument given by the name of this function
+        """
+        v = key_keyword(v)
+        self.update(v)
+
     def keyword_lamps(self, v):
         """ Lamps being used
 

--- a/pypit/core/arsetup.py
+++ b/pypit/core/arsetup.py
@@ -706,7 +706,7 @@ def write_sorted(group_file, fitstbl, group_dict, setup_dict):
     ff.write('##end\n')
     ff.close()
 
-def build_group_dict(fitstbl, setupIDs, all_sci_idx):
+def build_group_dict(fitstbl, setupIDs, all_sci_idx, all_sci_ID):
     """ Generate a group dict
     Only used for generating the .sorted output file
 
@@ -727,6 +727,7 @@ def build_group_dict(fitstbl, setupIDs, all_sci_idx):
     for sc,setupID in enumerate(setupIDs):
         #scidx = sciexp[sc]._idx_sci[0]
         scidx = all_sci_idx[sc]
+        sci_ID = all_sci_ID[sc]
         # Set group_key
         config_key = setupID[0]
         # Plan init
@@ -744,7 +745,7 @@ def build_group_dict(fitstbl, setupIDs, all_sci_idx):
             if key in ['unknown', 'dark', 'failures']:
                 continue
             #for idx in settings_spect[key]['index'][sc]:
-            indices = arsort.ftype_indices(fitstbl, key, scidx)
+            indices = arsort.ftype_indices(fitstbl, key, sci_ID)
             #for idx in settings_spect[key]['index'][sc]:
             for idx in indices:
                 # Only add if new

--- a/pypit/core/arsetup.py
+++ b/pypit/core/arsetup.py
@@ -682,7 +682,7 @@ def write_sorted(group_file, fitstbl, group_dict, setup_dict):
     ftypes.sort()
     # Loop on Setup
     asciiord = np.array(['filename', 'date', 'frameno', 'frametype',
-                         'target', 'exptime', 'dispname', 'decker'])
+                         'target', 'exptime', 'dispname', 'decker', 'AB_frame'])
     for setup in setups:
         ff.write('##########################################################\n')
         in_setup = []

--- a/pypit/core/arsort.py
+++ b/pypit/core/arsort.py
@@ -20,6 +20,8 @@ import shutil
 
 import numpy as np
 
+from astropy.coordinates import SkyCoord
+from astropy.table import Column
 from astropy.table import Table
 from astropy import units
 
@@ -528,6 +530,91 @@ def build_frametype_list(fitstbl):
     # Return
     return ftypes
 
+def match_ABBA(fitstbl):
+    # Make coords for all observations, including calibration frames
+    coords = SkyCoord(ra=fitstbl['ra'], dec=fitstbl['dec'], unit='deg')
+
+    # Indices of files classified as science frames
+    sci_idx = np.where(fitstbl['science'])[0]
+
+    # Create a mask, currently all True
+    mask = np.ones(np.sum(len(fitstbl)), dtype=bool)
+
+    # Create empty dictionary of targets
+    targets = {}
+
+    # Set science frames to False in the mask
+    mask[sci_idx] = False
+
+    while np.any(~mask):
+        idx = np.where(~mask)[0][0]
+        # Find indices corresponding to any others files that match the coordinates of current science frame in consideration
+        match = coords[idx].separation(coords[sci_idx]).deg < 1e-2 # 1e-2 separation is arbitrary
+        # Add this science target to the dictionary
+        targ_name = fitstbl[idx]['target']  # Grab the target name from fitstbl
+        # Create that target in dict and add corresponding indices that point to the relevant science frames
+        targets[targ_name] = sci_idx[match]
+        # Turn mask 'off' (i.e., to True) now that they have been grouped to this target
+        mask[targets[targ_name]] = True
+        #print(mask)
+
+    # Create an empty list of filenames that will store each frame's buddy A/B frame
+    AB_frame = [''] * len(fitstbl)
+
+    for key, value in targets.items():
+
+        #print(key, value)
+
+        files = fitstbl['filename'][value]
+        #print(files)
+
+        # Check here that there are more than 1 files and that # of files is even
+        if len(files) == 1:
+            msgs.warn('Cannot perform NIR A-B reduction on targets with 1 file')
+        elif len(files) % 2 != 0:
+            msgs.warn('Expected an even number of files associated with target ' + key)
+        #### Check for increasing time? Files are read in numerical sequential order -- should be in order
+        #### of increasing time anyway..?
+
+        # Assume that the files are initially in ABBA order and proceed
+        # ABBA coordinates for this target
+        ABBA_coords = coords[value]
+        # ABBA_coords = SkyCoord(ra=nod_ra, dec=nod_dec, unit='deg')
+
+        # Break files into ABBA groups (includes 'remainder' if there are only 2 files)
+        ABBA_groups = [ABBA_coords[i:i + 4] for i in range(0, len(ABBA_coords), 4)]
+        value_groups = [value[i:i + 4] for i in range(0, len(ABBA_coords), 4)]
+
+        for group in range(len(ABBA_groups)):
+            # Warn user that if there are any groups of only 2 files, assuming they are in order of A and B
+            if len(ABBA_groups[group]) == 2:
+                msgs.info('Assuming these two frames are A and B frame.')
+            # Check that we have a 4-file, ABBA sequence
+            elif len(ABBA_groups[group]) == 4:
+                # Check that frames 1, 4 of an ABBA sequence are at the same nod position (A) based on their RA, DEC
+                if not ABBA_coords[0].separation(ABBA_coords[-1]).deg < 5e-4:
+                    print(ABBA_groups[group])
+                    msgs.warn('Are frames ' + str((group * 4) + 1) + ' and ' + str(
+                        (group * 4) + 4) + ' for target ' + key + ' both A frames?')
+                # Check that frames 2, 3 of an ABBA sequence are both at the same nod position (B)
+                if not ABBA_coords[1].separation(ABBA_coords[2]).deg < 5e-4:
+                    msgs.warn('Are frames ' + str((group * 4) + 2) + ' and ' + str(
+                        (group * 4) + 3) + ' for target ' + key + ' both B frames?')
+            # Perhaps this isn't needed..? Should files either be in 4 or 2 at this point?
+            else:
+                msgs.warn('Check number of frames for this target -- files are not grouped in ABBA or AB')
+
+            # Create a copy of the array value_groups[group] (which gives the indices corresponding to the 4/2 ABBA/AB files in consideration)
+            AB_idx_flip = np.copy(value_groups[group])
+            # Flip such that, for example, (1, 2, 3, 4) --> (2, 1, 4, 3)
+            AB_idx_flip[::2], AB_idx_flip[1::2] = value_groups[group][1::2], value_groups[group][::2]
+
+            # Fill in AB_frame list
+            for i in range(len(value_groups[group])):
+                AB_frame[value_groups[group][i]] = fitstbl['filename'][AB_idx_flip[i]]
+
+    return AB_frame
+
 '''
 def sort_write(fitsdict, filesort, space=3):
     """
@@ -931,6 +1018,12 @@ def match_to_science(fitstbl, settings_spect, settings_argflag):
                     fitstbl['sci_ID'][wa[:numfr]] |= 2**ss  # Flip the switch (if need be)
 
     msgs.info("Science frames successfully matched to calibration frames")
+
+    # How to do this if statement only if '--custom' is on?
+    if settings_argflag['run']['spectrograph'] == 'keck_nirspec':
+        AB = Column(match_ABBA(fitstbl), name='AB_frame')
+
+    fitstbl.add_column(AB)
     return fitstbl
 
 '''

--- a/pypit/data/settings/archive/settings.2018-05-31.keck_nirspec
+++ b/pypit/data/settings/archive/settings.2018-05-31.keck_nirspec
@@ -1,0 +1,127 @@
+### Detector properties
+mosaic ndet 1                         # Number of detectors in the mosaic
+mosaic longitude 155.47833            # Longitude of the telescope (NOTE: West should correspond to positive longitudes)
+mosaic latitude 19.82833              # Latitude of the telescope
+mosaic elevation 4160.0               # Elevation of the telescope (in m)
+mosaic minexp 1.0                     # Minimum exposure time (s)
+mosaic reduction ARMLSD               # Which reduction pipeline should be used for this instrument
+mosaic camera NIRSPEC                   # Which reduction pipeline should be used for this instrument
+
+det01 xgap 0.0                        # Gap between the square detector pixels (expressed as a fraction of the x pixel size -- x is predominantly the dispersion axis)
+det01 ygap 0.0                        # Gap between the square detector pixels (expressed as a fraction of the y pixel size -- x is predominantly the dispersion axis)
+det01 ysize 1.0                       # The size of a pixel in the y-direction as a multiple of the x pixel size (i.e. xsize = 1.0 -- x is predominantly the dispersion axis)
+det01 darkcurr 0.8                    # Dark current (e-/hour)
+det01 platescale 0.193                # arcsec per pixel in the spatial dimension for an unbinned pixel, low-res mode; https://www2.keck.hawaii.edu/koa/public/nspec/nirspec_data_description.html
+det01 saturation 65535.0              # The detector Saturation level
+det01 nonlinear 0.76                  # Percentage of detector range which is linear (i.e. everything above nonlinear*saturation will be flagged as saturated)
+det01 numamplifiers 1                 # Number of amplifiers
+det01 gain 5.8                        # Gain (e-/ADU) values for the amplifier; https://www2.keck.hawaii.edu/inst/nirspec/Specifications.html
+det01 ronoise 23                      # RN (e-) for the amplifier
+det01 suffix None                     # Suffix to be appended to all saved calibration and extraction frames
+det01 dataext01 0                     # Extension number of the data
+det01 datasec01 [:,:]                 # Either the data sections or the header keyword where the valid data sections can be obtained
+det01 oscansec01 [:,:]                # Either the overscan sections or the header keyword where the valid overscan sections can be obtained
+
+### Checks to perform
+check 01.INSTRUME NIRSPEC              # THIS IS A MUST! It checks the instrument
+check 01.NAXIS 2                       # THIS IS A MUST! It performs a standard check to make sure the data are 2D.
+check 01.NAXIS1 1024                   # Checks number of pixels in axis 2
+check 01.NAXIS2 1024                   # Checks number of pixels in axis 2
+#?check 02.CCDGEOM LBNL Thick High-Resistivity   # Check the CCD name (replace any spaces with underscores)
+#?check 02.CCDNAME 19-3                # Check the CCD name (replace any spaces with underscores)
+#?check 04.CCDNAME 19-2                # Check the CCD name (replace any spaces with underscores)
+
+### Keyword Identifiers
+keyword date 01.DATE-OBS
+keyword target 01.OBJECT               # Header keyword for the name given by the observer to a given frame
+keyword exptime 01.ELAPTIME            # Exposure time keyword; equals ITIME * COADDS
+keyword naxis0 01.NAXIS2               # Number of pixels along the zeroth axis;;;; which axis is "zeroth"??
+keyword naxis1 01.NAXIS1               # Number of pixels along the first axis
+keyword filter1 01.FILNAME             # Filter 1
+keyword hatch 01.CALMPOS               # Cal. Mirror Position, 0=out, 1=in
+keyword slitwid 01.SLITWIDT            # Slit width
+keyword slitlen 01.SLITLEN             # Slit length
+keyword lampname01 NEON                # Name of a lamp
+keyword lampstat01 01.NEON             # Status of a lamp
+keyword lampname02 ARGON               # Name of a lamp
+keyword lampstat02 01.ARGON            # Status of a lamp
+keyword lampname03 KRYPTON             # Name of a lamp
+keyword lampstat03 01.KRYPTON          # Status of a lamp
+keyword lampname04 XENON               # Name of a lamp
+keyword lampstat04 01.XENON            # Status of a lamp
+keyword lampname05 ETALON              # Name of a lamp
+keyword lampstat05 01.ETALON           # Status of a lamp
+keyword lampname06 FLAT                # Name of a lamp
+keyword lampstat06 01.FLAT             # Status of a lamp
+keyword dispname 01.DISPERS            # Grating name
+#keyword dispangle 01.GRANGLE           # Grating angle
+keyword imagetype 01.IMAGETYP          # KOA generated keyword for image type
+
+### Fits properties
+fits numhead 1                         # How many headers need to be read in for a given file
+fits headext01 0                       # Extension number of header (one for each headnum, starting with 01)
+fits numlamps 6                        # How many lamps are there listed in the header
+
+### Science frames
+science check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+science check condition2 hatch=0       # Required for science; 0 is "out" for NIRSPEC
+science check condition3 exptime>=1    # Arbitrary exptime limit
+science check condition4 imagetype=object # Check that KOA keyword is 'object'
+
+### Standard Star frames
+standard check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+standard check condition2 hatch=0      # Required for standard; 0 is "out" for NIRSPEC
+standard check condition3 imagetype=object # Check that KOA keyword is object
+standard match dispname ''            # Check the same decker as the science frame was used
+#standard match dichroic ''            # Check the same decker as the science frame was used
+#standard match binning ''             # Match the shape of standard and science frames
+#standard match dispangle |<=0.02      # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Bias/Dark frames
+bias check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+bias check condition2 hatch=0          # Required for bias
+bias check condition3 exptime<=1        # Required for bias
+bias check condition4 imagetype=dark # Check that KOA keyword is 'dark'
+#bias match binning ''             	   # Match the shape of standard and science frames
+
+### Pixel Flat frames -- Dome Flat required
+pixelflat number 3                     # Number of flat frames to use
+pixelflat check condition1 hatch=1     # Required for pixel flats;;;; hatch=1 for dome flats and arcs
+pixelflat check condition2 exptime<30  # Avoid stars
+pixelflat check condition3 lampstat06=1
+pixelflat check condition4 imagetype=flatlamp # Check that KOA keyword is 'flatlamp'
+#pixelflat match binning ''            # Match the shape of standard and science frames
+pixelflat match decker ''             # Check the same decker as the science frame was used
+#pixelflat match dichroic ''           # Check the same decker as the science frame was used
+pixelflat match dispname ''           # Check the same decker as the science frame was used
+#pixelflat match dispangle |<=0.02     # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Pinhole frames
+pinhole check condition1 exptime>999999 # Avoids any pinhole frames
+
+### Dark frames
+dark check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+#dark check condition2 exptime<5         # Avoids any dark frames
+dark check condition3 imagetype=dark # Check that KOA keyword is 'dark'
+
+### Trace frames
+trace check condition1 hatch=1         # Required for blaze flats;;;; hatch=1 for dome flats and arcs
+trace check condition2 exptime<30      # Avoid stars
+trace check condition3 lampstat06=1
+#trace match binning ''                # Match the shape of trace with science
+trace match decker ''                 # Check the same decker as the science frame was used
+#trace match dichroic ''               # Check the same decker as the science frame was used
+trace match dispname ''               # Check the same decker as the science frame was used
+#trace match dispangle |<=0.02         # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Arc frames
+arc check condition1 lampstat01=1|lampstat02=1|lampstat03=1|lampstat04=1|lampstat05=1
+arc check condition2 hatch=1           # Required for arcs; 1 = "in" = closed
+arc check condition3 imagetype=arclamp # Check that KOA keyword is 'arclamp'
+#arc match binning ''                  # Match the shape of arcs with science
+#arc match dichroic ''                 # Check the same decker as the science frame was used
+arc match dispname ''                 # Check the same decker as the science frame was used
+#arc match dispangle |<=0.02           # Match the grating angle (no idea if this is reasonable for LRISr)
+
+# Make some changes to the arguments and flags
+settings trace dispersion direction 0

--- a/pypit/data/settings/archive/settings.2018-05-31.keck_nirspec
+++ b/pypit/data/settings/archive/settings.2018-05-31.keck_nirspec
@@ -82,7 +82,7 @@ bias check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampst
 bias check condition2 hatch=0          # Required for bias
 bias check condition3 exptime<=1        # Required for bias
 bias check condition4 imagetype=dark # Check that KOA keyword is 'dark'
-#bias match binning ''             	   # Match the shape of standard and science frames
+bias match binning ''             	   # Match the shape of standard and science frames
 
 ### Pixel Flat frames -- Dome Flat required
 pixelflat number 3                     # Number of flat frames to use

--- a/pypit/data/settings/settings.keck_nirspec
+++ b/pypit/data/settings/settings.keck_nirspec
@@ -39,6 +39,8 @@ keyword naxis0 01.NAXIS2               # Number of pixels along the zeroth axis;
 keyword naxis1 01.NAXIS1               # Number of pixels along the first axis
 keyword filter1 01.FILNAME             # Filter 1
 keyword hatch 01.CALMPOS               # Cal. Mirror Position, 0=out, 1=in
+keyword slitwid 01.SLITWIDT            # Slit width
+keyword slitlen 01.SLITLEN             # Slit length
 keyword lampname01 NEON                # Name of a lamp
 keyword lampstat01 01.NEON             # Status of a lamp
 keyword lampname02 ARGON               # Name of a lamp
@@ -53,6 +55,7 @@ keyword lampname06 FLAT                # Name of a lamp
 keyword lampstat06 01.FLAT             # Status of a lamp
 keyword dispname 01.DISPERS            # Grating name
 #keyword dispangle 01.GRANGLE           # Grating angle
+keyword imagetype 01.IMAGETYP          # KOA generated keyword for image type
 
 ### Fits properties
 fits numhead 1                         # How many headers need to be read in for a given file
@@ -62,12 +65,14 @@ fits numlamps 6                        # How many lamps are there listed in the 
 ### Science frames
 science check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
 science check condition2 hatch=0       # Required for science; 0 is "out" for NIRSPEC
-science check condition3 exptime>20    # Arbitrary exptime limit
+science check condition3 exptime>=1    # Arbitrary exptime limit
+science check condition4 imagetype=object # Check that KOA keyword is 'object'
 
 ### Standard Star frames
 standard check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
 standard check condition2 hatch=0      # Required for standard; 0 is "out" for NIRSPEC
-#standard match dispname ''            # Check the same decker as the science frame was used
+standard check condition3 imagetype=object # Check that KOA keyword is object
+standard match dispname ''            # Check the same decker as the science frame was used
 #standard match dichroic ''            # Check the same decker as the science frame was used
 #standard match binning ''             # Match the shape of standard and science frames
 #standard match dispangle |<=0.02      # Match the grating angle (no idea if this is reasonable for LRISr)
@@ -76,6 +81,7 @@ standard check condition2 hatch=0      # Required for standard; 0 is "out" for N
 bias check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
 bias check condition2 hatch=0          # Required for bias
 bias check condition3 exptime<=1        # Required for bias
+bias check condition4 imagetype=dark # Check that KOA keyword is 'dark'
 #bias match binning ''             	   # Match the shape of standard and science frames
 
 ### Pixel Flat frames -- Dome Flat required
@@ -83,10 +89,11 @@ pixelflat number 3                     # Number of flat frames to use
 pixelflat check condition1 hatch=1     # Required for pixel flats;;;; hatch=1 for dome flats and arcs
 pixelflat check condition2 exptime<30  # Avoid stars
 pixelflat check condition3 lampstat06=1
+pixelflat check condition4 imagetype=flatlamp # Check that KOA keyword is 'flatlamp'
 #pixelflat match binning ''            # Match the shape of standard and science frames
-#pixelflat match decker ''             # Check the same decker as the science frame was used
+pixelflat match decker ''             # Check the same decker as the science frame was used
 #pixelflat match dichroic ''           # Check the same decker as the science frame was used
-#pixelflat match dispname ''           # Check the same decker as the science frame was used
+pixelflat match dispname ''           # Check the same decker as the science frame was used
 #pixelflat match dispangle |<=0.02     # Match the grating angle (no idea if this is reasonable for LRISr)
 
 ### Pinhole frames
@@ -94,24 +101,26 @@ pinhole check condition1 exptime>999999 # Avoids any pinhole frames
 
 ### Dark frames
 dark check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
-dark check condition2 exptime<5         # Avoids any dark frames
+#dark check condition2 exptime<5         # Avoids any dark frames
+dark check condition3 imagetype=dark # Check that KOA keyword is 'dark'
 
 ### Trace frames
 trace check condition1 hatch=1         # Required for blaze flats;;;; hatch=1 for dome flats and arcs
 trace check condition2 exptime<30      # Avoid stars
 trace check condition3 lampstat06=1
 #trace match binning ''                # Match the shape of trace with science
-#trace match decker ''                 # Check the same decker as the science frame was used
+trace match decker ''                 # Check the same decker as the science frame was used
 #trace match dichroic ''               # Check the same decker as the science frame was used
-#trace match dispname ''               # Check the same decker as the science frame was used
+trace match dispname ''               # Check the same decker as the science frame was used
 #trace match dispangle |<=0.02         # Match the grating angle (no idea if this is reasonable for LRISr)
 
 ### Arc frames
 arc check condition1 lampstat01=1|lampstat02=1|lampstat03=1|lampstat04=1|lampstat05=1
 arc check condition2 hatch=1           # Required for arcs; 1 = "in" = closed
+arc check condition3 imagetype=arclamp # Check that KOA keyword is 'arclamp'
 #arc match binning ''                  # Match the shape of arcs with science
 #arc match dichroic ''                 # Check the same decker as the science frame was used
-#arc match dispname ''                 # Check the same decker as the science frame was used
+arc match dispname ''                 # Check the same decker as the science frame was used
 #arc match dispangle |<=0.02           # Match the grating angle (no idea if this is reasonable for LRISr)
 
 # Make some changes to the arguments and flags

--- a/pypit/data/settings/settings.keck_nirspec
+++ b/pypit/data/settings/settings.keck_nirspec
@@ -1,0 +1,118 @@
+### Detector properties
+mosaic ndet 1                         # Number of detectors in the mosaic
+mosaic longitude 155.47833            # Longitude of the telescope (NOTE: West should correspond to positive longitudes)
+mosaic latitude 19.82833              # Latitude of the telescope
+mosaic elevation 4160.0               # Elevation of the telescope (in m)
+mosaic minexp 1.0                     # Minimum exposure time (s)
+mosaic reduction ARMLSD               # Which reduction pipeline should be used for this instrument
+mosaic camera NIRSPEC                   # Which reduction pipeline should be used for this instrument
+
+det01 xgap 0.0                        # Gap between the square detector pixels (expressed as a fraction of the x pixel size -- x is predominantly the dispersion axis)
+det01 ygap 0.0                        # Gap between the square detector pixels (expressed as a fraction of the y pixel size -- x is predominantly the dispersion axis)
+det01 ysize 1.0                       # The size of a pixel in the y-direction as a multiple of the x pixel size (i.e. xsize = 1.0 -- x is predominantly the dispersion axis)
+det01 darkcurr 0.8                    # Dark current (e-/hour)
+det01 platescale 0.193                # arcsec per pixel in the spatial dimension for an unbinned pixel, low-res mode; https://www2.keck.hawaii.edu/koa/public/nspec/nirspec_data_description.html
+det01 saturation 65535.0              # The detector Saturation level
+det01 nonlinear 0.76                  # Percentage of detector range which is linear (i.e. everything above nonlinear*saturation will be flagged as saturated)
+det01 numamplifiers 1                 # Number of amplifiers
+det01 gain 5.8                        # Gain (e-/ADU) values for the amplifier; https://www2.keck.hawaii.edu/inst/nirspec/Specifications.html
+det01 ronoise 23                      # RN (e-) for the amplifier
+det01 suffix None                     # Suffix to be appended to all saved calibration and extraction frames
+det01 dataext01 0                     # Extension number of the data
+det01 datasec01 [:,:]                 # Either the data sections or the header keyword where the valid data sections can be obtained
+det01 oscansec01 [:,:]                # Either the overscan sections or the header keyword where the valid overscan sections can be obtained
+
+### Checks to perform
+check 01.INSTRUME NIRSPEC              # THIS IS A MUST! It checks the instrument
+check 01.NAXIS 2                       # THIS IS A MUST! It performs a standard check to make sure the data are 2D.
+check 01.NAXIS1 1024                   # Checks number of pixels in axis 2
+check 01.NAXIS2 1024                   # Checks number of pixels in axis 2
+#?check 02.CCDGEOM LBNL Thick High-Resistivity   # Check the CCD name (replace any spaces with underscores)
+#?check 02.CCDNAME 19-3                # Check the CCD name (replace any spaces with underscores)
+#?check 04.CCDNAME 19-2                # Check the CCD name (replace any spaces with underscores)
+
+### Keyword Identifiers
+keyword date 01.DATE-OBS
+keyword target 01.OBJECT               # Header keyword for the name given by the observer to a given frame
+keyword exptime 01.ELAPTIME            # Exposure time keyword; equals ITIME * COADDS
+keyword naxis0 01.NAXIS2               # Number of pixels along the zeroth axis;;;; which axis is "zeroth"??
+keyword naxis1 01.NAXIS1               # Number of pixels along the first axis
+keyword filter1 01.FILNAME             # Filter 1
+keyword hatch 01.CALMPOS               # Cal. Mirror Position, 0=out, 1=in
+keyword lampname01 NEON                # Name of a lamp
+keyword lampstat01 01.NEON             # Status of a lamp
+keyword lampname02 ARGON               # Name of a lamp
+keyword lampstat02 01.ARGON            # Status of a lamp
+keyword lampname03 KRYPTON             # Name of a lamp
+keyword lampstat03 01.KRYPTON          # Status of a lamp
+keyword lampname04 XENON               # Name of a lamp
+keyword lampstat04 01.XENON            # Status of a lamp
+keyword lampname05 ETALON              # Name of a lamp
+keyword lampstat05 01.ETALON           # Status of a lamp
+keyword lampname06 FLAT                # Name of a lamp
+keyword lampstat06 01.FLAT             # Status of a lamp
+#keyword dispname 01.GRANAME            # Grating name
+#keyword dispangle 01.GRANGLE           # Grating angle
+
+### Fits properties
+fits numhead 1                         # How many headers need to be read in for a given file
+fits headext01 0                       # Extension number of header (one for each headnum, starting with 01)
+fits numlamps 6                        # How many lamps are there listed in the header
+
+### Science frames
+science check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+science check condition2 hatch=0       # Required for science; 0 is "out" for NIRSPEC
+science check condition3 exptime>20    # Arbitrary exptime limit
+
+### Standard Star frames
+standard check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+standard check condition2 hatch=0      # Required for standard; 0 is "out" for NIRSPEC
+#standard match dispname ''            # Check the same decker as the science frame was used
+#standard match dichroic ''            # Check the same decker as the science frame was used
+#standard match binning ''             # Match the shape of standard and science frames
+#standard match dispangle |<=0.02      # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Bias/Dark frames
+bias check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+bias check condition2 hatch=0          # Required for bias
+bias check condition3 exptime<=1        # Required for bias
+#bias match binning ''             	   # Match the shape of standard and science frames
+
+### Pixel Flat frames -- Dome Flat required
+pixelflat number 3                     # Number of flat frames to use
+pixelflat check condition1 hatch=1     # Required for pixel flats;;;; hatch=1 for dome flats and arcs
+pixelflat check condition2 exptime<30  # Avoid stars
+pixelflat check condition3 lampstat06=1
+#pixelflat match binning ''            # Match the shape of standard and science frames
+#pixelflat match decker ''             # Check the same decker as the science frame was used
+#pixelflat match dichroic ''           # Check the same decker as the science frame was used
+#pixelflat match dispname ''           # Check the same decker as the science frame was used
+#pixelflat match dispangle |<=0.02     # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Pinhole frames
+pinhole check condition1 exptime>999999 # Avoids any pinhole frames
+
+### Dark frames
+dark check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+dark check condition2 exptime<5         # Avoids any dark frames
+
+### Trace frames
+trace check condition1 hatch=1         # Required for blaze flats;;;; hatch=1 for dome flats and arcs
+trace check condition2 exptime<30      # Avoid stars
+trace check condition3 lampstat06=1
+#trace match binning ''                # Match the shape of trace with science
+#trace match decker ''                 # Check the same decker as the science frame was used
+#trace match dichroic ''               # Check the same decker as the science frame was used
+#trace match dispname ''               # Check the same decker as the science frame was used
+#trace match dispangle |<=0.02         # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Arc frames
+arc check condition1 lampstat01=1|lampstat02=1|lampstat03=1|lampstat04=1|lampstat05=1
+arc check condition2 hatch=1           # Required for arcs; 1 = "in" = closed
+#arc match binning ''                  # Match the shape of arcs with science
+#arc match dichroic ''                 # Check the same decker as the science frame was used
+#arc match dispname ''                 # Check the same decker as the science frame was used
+#arc match dispangle |<=0.02           # Match the grating angle (no idea if this is reasonable for LRISr)
+
+# Make some changes to the arguments and flags
+settings trace dispersion direction 0

--- a/pypit/data/settings/settings.keck_nirspec
+++ b/pypit/data/settings/settings.keck_nirspec
@@ -51,7 +51,7 @@ keyword lampname05 ETALON              # Name of a lamp
 keyword lampstat05 01.ETALON           # Status of a lamp
 keyword lampname06 FLAT                # Name of a lamp
 keyword lampstat06 01.FLAT             # Status of a lamp
-#keyword dispname 01.GRANAME            # Grating name
+keyword dispname 01.DISPERS            # Grating name
 #keyword dispangle 01.GRANGLE           # Grating angle
 
 ### Fits properties

--- a/pypit/data/settings/settings.keck_nirspec
+++ b/pypit/data/settings/settings.keck_nirspec
@@ -82,7 +82,7 @@ bias check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampst
 bias check condition2 hatch=0          # Required for bias
 bias check condition3 exptime<=1        # Required for bias
 bias check condition4 imagetype=dark # Check that KOA keyword is 'dark'
-#bias match binning ''             	   # Match the shape of standard and science frames
+bias match binning ''             	   # Match the shape of standard and science frames
 
 ### Pixel Flat frames -- Dome Flat required
 pixelflat number 3                     # Number of flat frames to use

--- a/pypit/pypitsetup.py
+++ b/pypit/pypitsetup.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 import inspect
 import numpy as np
 
-from importlib import reload
+#from importlib import reload
 
 from astropy.table import hstack, Table
 
@@ -78,7 +78,6 @@ class PypitSetup(object):
         fitstbl : Table
 
         """
-        reload(arload)
         self.fitstbl, updates = arload.load_headers(file_list, self.settings_spect,
                                                     self.settings_argflag)
         self.fitstbl.sort('time')
@@ -97,7 +96,6 @@ class PypitSetup(object):
           Dict describing the various setups
         """
         #
-        reload(arsetup)
         all_sci_idx = np.where(self.fitstbl['science'])[0]
         all_sci_ID = self.fitstbl['sci_ID'][self.fitstbl['science']]
         self.group_dict = arsetup.build_group_dict(self.fitstbl, self.setupIDs, all_sci_idx, all_sci_ID)

--- a/pypit/pypitsetup.py
+++ b/pypit/pypitsetup.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 import inspect
 import numpy as np
 
-#from importlib import reload
+from importlib import reload
 
 from astropy.table import hstack, Table
 
@@ -78,6 +78,7 @@ class PypitSetup(object):
         fitstbl : Table
 
         """
+        reload(arload)
         self.fitstbl, updates = arload.load_headers(file_list, self.settings_spect,
                                                     self.settings_argflag)
         self.fitstbl.sort('time')
@@ -96,8 +97,10 @@ class PypitSetup(object):
           Dict describing the various setups
         """
         #
-        all_sci_idx = self.fitstbl['sci_ID'].data[self.fitstbl['science']]
-        self.group_dict = arsetup.build_group_dict(self.fitstbl, self.setupIDs, all_sci_idx)
+        reload(arsetup)
+        all_sci_idx = np.where(self.fitstbl['science'])[0]
+        all_sci_ID = self.fitstbl['sci_ID'][self.fitstbl['science']]
+        self.group_dict = arsetup.build_group_dict(self.fitstbl, self.setupIDs, all_sci_idx, all_sci_ID)
 
         # Write .sorted file
         if len(self.group_dict) > 0:

--- a/pypit/pypitsetup.py
+++ b/pypit/pypitsetup.py
@@ -170,6 +170,22 @@ class PypitSetup(object):
         self.steps.append(inspect.stack()[0][3])
         return self.setup_dict
 
+    def match_ABBA(self):
+        """
+          Matches science frames to their partner A/B frame
+          Mainly a wrapper to arsort.match_ABBA()
+
+        Returns
+        -------
+        self.fitstbl -- Updated with 'AB_frame' column
+
+        """
+        self.fitstbl = arsort.match_ABBA(self.fitstbl)
+
+        # Step
+        self.steps.append(inspect.stack()[0][3])
+        return self.fitstbl
+
     def match_to_science(self):
         """
           Matches calibration frames to the Science

--- a/pypit/tests/test_pypitsetup.py
+++ b/pypit/tests/test_pypitsetup.py
@@ -28,19 +28,15 @@ def data_path(filename):
     return os.path.join(data_dir, filename)
 
 
-def settings_kludge():
+def settings_kludge(instr='shane_kast_blue'):
     # We be replaced with the settings Refactor
     from pypit import arparse as settings
-    settings.dummy_settings()
-    settings.argflag['run']['spectrograph'] = 'shane_kast_blue'
+    settings.dummy_settings(spectrograph=instr)
+    settings.argflag['run']['spectrograph'] = instr
     settings.argflag['reduce']['masters']['setup'] = 'C_01_aa'
     #
-    # Load default spectrograph settings
-    spect = settings.get_spect_class(('ARMLSD', 'shane_kast_blue', 'pypit'))  # '.'.join(redname.split('.')[:-1])))
-    lines = spect.load_file(base=True)  # Base spectrograph settings
-    spect.set_paramlist(lines)
-    lines = spect.load_file()  # Instrument specific
-    spect.set_paramlist(lines)
+    if 'nirspec' in instr:
+        pytest.set_trace()
     return settings.argflag, settings.spect
 
 def test_init():
@@ -131,7 +127,7 @@ def test_match_ABBA():
     files = glob.glob(file_root+'*')
     assert len(files) > 0
     # Settings
-    settings_argflag, settings_spect = settings_kludge()
+    settings_argflag, settings_spect = settings_kludge('keck_nirspec')
     # Init
     setupc = pypitsetup.PypitSetup(settings_argflag, settings_spect)
     # fitstbl

--- a/pypit/tests/test_pypitsetup.py
+++ b/pypit/tests/test_pypitsetup.py
@@ -122,6 +122,29 @@ def test_match():
     fitstbl = setupc.match_to_science()
     assert fitstbl['sci_ID'][fitstbl['science']].tolist() == [1,2,4]
 
+def test_match_ABBA():
+    if skip_test:
+        assert True
+        return
+    # Check for files
+    file_root = os.getenv('PYPIT_DEV') + 'RAW_DATA/Keck_NIRSPEC/NIRSPEC-1/NS'
+    files = glob.glob(file_root+'*')
+    assert len(files) > 0
+    # Settings
+    settings_argflag, settings_spect = settings_kludge()
+    # Init
+    setupc = pypitsetup.PypitSetup(settings_argflag, settings_spect)
+    # fitstbl
+    _ = setupc.build_fitstbl(files)
+
+    # Type
+    _ = setupc.type_data()
+
+    # Match to science
+    fitstbl = setupc.match_to_science()
+    fitstbl = setupc.match_ABBA()
+
+    assert fitstbl['AB_frame'][-1] == 'NS.20160414.55235.fits.gz'
 
 def test_run():
     if skip_test:

--- a/pypit/tests/test_pypitsetup.py
+++ b/pypit/tests/test_pypitsetup.py
@@ -128,6 +128,8 @@ def test_match_ABBA():
     assert len(files) > 0
     # Settings
     settings_argflag, settings_spect = settings_kludge('keck_nirspec')
+    settings_spect['bias']['number'] = 0
+    settings_spect['standard']['number'] = 0
     # Init
     setupc = pypitsetup.PypitSetup(settings_argflag, settings_spect)
     # fitstbl

--- a/pypit/tests/test_pypitsetup.py
+++ b/pypit/tests/test_pypitsetup.py
@@ -34,9 +34,6 @@ def settings_kludge(instr='shane_kast_blue'):
     settings.dummy_settings(spectrograph=instr)
     settings.argflag['run']['spectrograph'] = instr
     settings.argflag['reduce']['masters']['setup'] = 'C_01_aa'
-    #
-    if 'nirspec' in instr:
-        pytest.set_trace()
     return settings.argflag, settings.spect
 
 def test_init():


### PR DESCRIPTION
Introduces a NIRSPEC settings file and adds an 'imagetype' keyword to help better sort the NIRSPEC calibration and science frames. For objects classified as 'science', finds a matching A/B frame and prints it in the output .pypit file.