### PR TITLE
Final integration

### DIFF
--- a/pypit/arparse.py
+++ b/pypit/arparse.py
@@ -4562,7 +4562,7 @@ def dummy_settings(pypitdir=None, nfile=10, spectrograph='shane_kast_blue',
 
     """
     # Dummy argflag
-    if spectrograph not in ['shane_kast_blue', 'keck_nirspec']:
+    if spectrograph not in ['shane_kast_blue', 'keck_nirspec', 'keck_deimos']:
         msgs.error("Not setup for your instrument")  # You will need to fuss with scidx
     argf = get_argflag_class(("ARMS", spectrograph))
     argf.init_param()

--- a/pypit/arparse.py
+++ b/pypit/arparse.py
@@ -4562,7 +4562,7 @@ def dummy_settings(pypitdir=None, nfile=10, spectrograph='shane_kast_blue',
 
     """
     # Dummy argflag
-    if spectrograph not in ['shane_kast_blue', 'keck_nirspec', 'keck_deimos']:
+    if spectrograph not in ['shane_kast_blue', 'keck_nirspec', 'keck_deimos', 'keck_nires']:
         msgs.error("Not setup for your instrument")  # You will need to fuss with scidx
     argf = get_argflag_class(("ARMS", spectrograph))
     argf.init_param()

--- a/pypit/arutils.py
+++ b/pypit/arutils.py
@@ -166,7 +166,7 @@ def bspline_profile(xdata, ydata, invvar, profile_basis, upper=5, lower=5,
             sset: object
                bspline object
             outmask: : :class:`numpy.ndarray`
-               output mask which the same size as xdata
+               output mask which the same size as xdata, such that rejected points have outmask set to False
             yfit  : :class:`numpy.ndarray`
                result of the bspline fit (same size as xdata)
             reduced_chi: float

--- a/pypit/core/ararc.py
+++ b/pypit/core/ararc.py
@@ -172,6 +172,7 @@ def detect_lines(censpec, nfitpix=5, nonlinear=None):
       The spectrum used to find detections. This spectrum has
       had any "continuum" emission subtracted off
     """
+    # TODO I don't see that there is any continuum subtraction being done here contrary to what the docs say.
 
     # Extract a rough spectrum of the arc in each order
     msgs.info("Detecting lines")

--- a/pypit/core/arextract.py
+++ b/pypit/core/arextract.py
@@ -91,7 +91,7 @@ def extract_asymbox2(image,left_in,right_in,ycen = None,weight_image = None):
         nTrace = dim[0]
         npix = dim[1]
 
-    if ycen == None:
+    if ycen is None:
         if ndim == 1:
             ycen_out = np.arange(npix, dtype='int')
         elif ndim == 2:
@@ -216,7 +216,7 @@ def extract_boxcar(image,trace_in, radius_in, ycen = None):
         nTrace = dim[0]
         npix = dim[1]
 
-    if ycen == None:
+    if ycen is None:
         if ndim == 1:
             ycen_out = np.arange(npix, dtype='int')
         elif ndim == 2:

--- a/pypit/core/arextract.py
+++ b/pypit/core/arextract.py
@@ -239,7 +239,7 @@ def extract_boxcar(image,trace_in, radius_in, ycen = None):
     return fextract
 
 
-def extract_optimal(waveimg, imgminsky, ivar, mask, oprof, skyimg, rn_img, box_radius, specobj):
+def extract_optimal(waveimg, imgminsky, ivar, mask, oprof, skyimg, rn2_img, box_radius, specobj):
 
     nspat = imgminsky.shape[1]
     nspec = imgminsky.shape[0]
@@ -247,7 +247,7 @@ def extract_optimal(waveimg, imgminsky, ivar, mask, oprof, skyimg, rn_img, box_r
     spec_vec = np.arange(nspec)
     spat_vec = np.arange(nspat)
 
-    var_no = np.abs(skyimg - np.sqrt(2.0) * rn_img) +rn_img**2
+    var_no = np.abs(skyimg - np.sqrt(2.0) * np.sqrt(rn2_img)) + rn2_img
 
     ispec, ispat = np.where(oprof > 0.0)
     mincol = np.min(ispat)
@@ -259,7 +259,7 @@ def extract_optimal(waveimg, imgminsky, ivar, mask, oprof, skyimg, rn_img, box_r
     ivar_sub = np.fmax(ivar[:,mincol:maxcol],0.0) # enforce positivity since these are used as weights
     vno_sub = np.fmax(var_no[:,mincol:maxcol],0.0)
 
-    rn2_sub = rn_img[:,mincol:maxcol]**2
+    rn2_sub = rn2_img[:,mincol:maxcol]
     img_sub = imgminsky[:,mincol:maxcol]
     sky_sub = skyimg[:,mincol:maxcol]
     oprof_sub = oprof[:,mincol:maxcol]
@@ -333,7 +333,7 @@ def extract_optimal(waveimg, imgminsky, ivar, mask, oprof, skyimg, rn_img, box_r
     var_box  = extract_boxcar(varimg*mask, specobj.trace_spat,box_radius, ycen = specobj.trace_spec)
     nvar_box  = extract_boxcar(var_no*mask, specobj.trace_spat,box_radius, ycen = specobj.trace_spec)
     sky_box  = extract_boxcar(skyimg*mask, specobj.trace_spat,box_radius, ycen = specobj.trace_spec)
-    rn2_box  = extract_boxcar(rn_img**2*mask, specobj.trace_spat,box_radius, ycen = specobj.trace_spec)
+    rn2_box  = extract_boxcar(rn2_img*mask, specobj.trace_spat,box_radius, ycen = specobj.trace_spec)
     rn_posind = (rn2_box > 0.0)
     rn_box = np.zeros(rn2_box.shape,dtype=float)
     rn_box[rn_posind] = np.sqrt(rn2_box[rn_posind])

--- a/pypit/core/arprocimg.py
+++ b/pypit/core/arprocimg.py
@@ -494,6 +494,7 @@ def gain_frame(datasec_img, namp, gain_list):
     datasec_img : ndarray
     namp : int
     gain_list : list
+    # TODO need to beef up the docs here
 
     Returns
     -------

--- a/pypit/core/arprocimg.py
+++ b/pypit/core/arprocimg.py
@@ -773,8 +773,8 @@ def variance_frame(datasec_img, det, sciframe, settings_det=None,
         if dnoise is None:
             dnoise = (settings_det['darkcurr'] * float(fitsdict["exptime"][idx])/3600.0)
         # Return
-        #varframe = np.abs(sciframe - np.sqrt(2)*np.sqrt(rnoise)) + rnoise + dnoise
-        #return varframe
-        return np.abs(sciframe.copy()) + rnoise + dnoise
+        varframe = np.abs(sciframe - np.sqrt(2)*np.sqrt(rnoise)) + rnoise + dnoise
+        return varframe
+#        return np.abs(sciframe.copy()) + rnoise + dnoise
 
 

--- a/pypit/core/arskysub.py
+++ b/pypit/core/arskysub.py
@@ -92,7 +92,7 @@ def bg_subtraction_slit(slit, slitpix, edge_mask, sciframe, varframe, tilts,
 
             #skybkpt = bspline_bkpts(wsky[pos_sky], nord=4, bkspace=bsp $
             #, / silent)
-            if PLOT_FIT:
+            if False:
                 from matplotlib import pyplot as plt
                 plt.clf()
                 ax = plt.gca()
@@ -121,13 +121,16 @@ def bg_subtraction_slit(slit, slitpix, edge_mask, sciframe, varframe, tilts,
     # Debugging/checking
     if PLOT_FIT:
         from matplotlib import pyplot as plt
+        from IPython import embed
+        goodbk = skyset.mask
+        yfit_bkpt = np.interp(skyset.breakpoints[goodbk], wsky,yfit)
         plt.clf()
         ax = plt.gca()
         ax.plot(wsky, sky, color='k', marker='o', markersize=0.3, mfc='k', fillstyle='full', linestyle='None')
-        ax.plot(wsky[~full_out], sky[~full_out], color='red', marker='+', markersize=1.0, mfc='red', fillstyle='full', linestyle='None')
-        #ax.scatter(wsky[full_out], sky[full_out])
-        #ax.scatter(wsky[~full_out], sky[~full_out], color='red')
+        ax.plot(wsky[~full_out], sky[~full_out], color='red', marker='+', markersize=1.5, mfc='red', fillstyle='full', linestyle='None')
         ax.plot(wsky, yfit, color='cornflowerblue')
+        ax.plot(skyset.breakpoints[goodbk], yfit_bkpt, color='lawngreen', marker='o', markersize=2.0, mfc='lawngreen', fillstyle='full', linestyle='None')
+        ax.set_ylim((0.99*yfit.min(),1.01*yfit.max()))
         plt.show()
 
     # Return

--- a/pypit/core/arskysub.py
+++ b/pypit/core/arskysub.py
@@ -16,7 +16,7 @@ from pypit import arpixels
 
 from pypit import ardebug as debugger
 
-
+# ToDO Fix masking logic. This code should take an ivar for consistency with rest of extraction
 def bg_subtraction_slit(slit, slitpix, edge_mask, sciframe, varframe, tilts,
                         bpm=None, crmask=None, tracemask=None, bsp=0.6, sigrej=3., POS_MASK=True, PLOT_FIT=False):
     """
@@ -126,8 +126,10 @@ def bg_subtraction_slit(slit, slitpix, edge_mask, sciframe, varframe, tilts,
         yfit_bkpt = np.interp(skyset.breakpoints[goodbk], wsky,yfit)
         plt.clf()
         ax = plt.gca()
-        ax.plot(wsky, sky, color='k', marker='o', markersize=0.3, mfc='k', fillstyle='full', linestyle='None')
-        ax.plot(wsky[~full_out], sky[~full_out], color='red', marker='+', markersize=1.5, mfc='red', fillstyle='full', linestyle='None')
+        was_fit = (sky_ivar > 0.0)
+        was_fit_and_masked = (was_fit == True) & (full_out = False)
+        ax.plot(wsky[was_fit], sky[was_fit], color='k', marker='o', markersize=0.4, mfc='k', fillstyle='full', linestyle='None')
+        ax.plot(wsky[was_fit_and_masked], sky[was_fit_and_masked], color='red', marker='+', markersize=1.5, mfc='red', fillstyle='full', linestyle='None')
         ax.plot(wsky, yfit, color='cornflowerblue')
         ax.plot(skyset.breakpoints[goodbk], yfit_bkpt, color='lawngreen', marker='o', markersize=2.0, mfc='lawngreen', fillstyle='full', linestyle='None')
         ax.set_ylim((0.99*yfit.min(),1.01*yfit.max()))

--- a/pypit/core/arskysub.py
+++ b/pypit/core/arskysub.py
@@ -100,7 +100,7 @@ def bg_subtraction_slit(slit, slitpix, edge_mask, sciframe, varframe, tilts,
                 #ax.scatter(wsky[~full_out], sky[~full_out], color='red')
                 #ax.plot(wsky, yfit, color='green')
                 plt.show()
-                debugger.set_trace()
+                #debugger.set_trace()
             lskyset, outmask, lsky_fit, red_chi = arutils.bspline_profile(
                 wsky[pos_sky], lsky, lsky_ivar, np.ones_like(lsky),
                 fullbkpt = tmp.breakpoints, upper=sigrej, lower=sigrej,
@@ -123,9 +123,11 @@ def bg_subtraction_slit(slit, slitpix, edge_mask, sciframe, varframe, tilts,
         from matplotlib import pyplot as plt
         plt.clf()
         ax = plt.gca()
-        ax.scatter(wsky[full_out], sky[full_out])
-        ax.scatter(wsky[~full_out], sky[~full_out], color='red')
-        ax.plot(wsky, yfit, color='green')
+        ax.plot(wsky, sky, color='k', marker='o', markersize=0.3, mfc='k', fillstyle='full', linestyle='None')
+        ax.plot(wsky[~full_out], sky[~full_out], color='red', marker='+', markersize=1.0, mfc='red', fillstyle='full', linestyle='None')
+        #ax.scatter(wsky[full_out], sky[full_out])
+        #ax.scatter(wsky[~full_out], sky[~full_out], color='red')
+        ax.plot(wsky, yfit, color='cornflowerblue')
         plt.show()
 
     # Return

--- a/pypit/core/artraceslits.py
+++ b/pypit/core/artraceslits.py
@@ -2762,9 +2762,8 @@ def trace_fweight(fimage, xinit_in, radius = 3.0, ycen=None, invvar=None):
 
 
 def trace_gweight(fimage, xinit_in, sigma = 1.0, ycen = None, invvar=None, maskval=-999999.9):
-    ''' Routine to recenter a trace using gaussian-weighted centroiding.
-
-    Python port of trace_gweight.pro from IDLUTILS
+    ''' Routine to recenter a trace using gaussian-weighted centroiding. Specifically the flux in the image is weighted
+    by the integral of a Gaussian over a pixel. Port of idlutils trace_gweight.pro algorithm
 
 
     Parameters
@@ -2801,7 +2800,7 @@ def trace_gweight(fimage, xinit_in, sigma = 1.0, ycen = None, invvar=None, maskv
          Formal propagated error on recentroided trace. These errors will only make sense if invvar is passed in, since
          otherwise invvar is set to 1.0.   The output will have the same shape as xinit i.e.  an 2-d  array with shape
          (nspec, nTrace) array if multiple traces were input, or a 1-d array with shape (nspec) for the case of a single
-         trace. Locations where the flux weighted centroid deviates from the input guess by  > radius, or where it falls
+         trace. Locations where the gaussian weighted centroid deviates from the input guess by  > radius, or where it falls
          off the image, will have this error set to 999 and will their xnew values set to that of the input trace. These
          should thus be masked in any fit.
 
@@ -2810,35 +2809,8 @@ def trace_gweight(fimage, xinit_in, sigma = 1.0, ycen = None, invvar=None, maskv
      Python port of trace_fweight.pro from IDLUTILS
      24-Mar-1999  Written by David Schlegel, Princeton.
      27-Jun-2018  Ported to python by X. Prochaska and J. Hennawi
-    """
+    '''
 
-
-    """ Determines the trace centroid by weighting the flux by the integral
-    of a Gaussian over a pixel
-    Port of SDSS trace_gweight algorithm
-
-    Parameters
-    ----------
-    fimage : ndarray
-      image to centroid on
-    xcen : ndarray
-      guess of centroids in x (column) dimension
-    ycen : ndarray (usually int)
-      guess of centroids in y (rows) dimension
-    sigma : float
-      Width of gaussian
-    invvar : ndarray, optional
-    maskval : float, optional
-      Value for masking
-
-    Returns
-    -------
-    xnew : ndarray
-      New estimate for trace in x-dimension
-    xerr : ndarray
-      Error estimate for trace.  Rejected points have maskval
-
-    """
     # Setup
     nx = fimage.shape[1]
     xnew = np.zeros_like(xcen)

--- a/pypit/core/artraceslits.py
+++ b/pypit/core/artraceslits.py
@@ -2695,7 +2695,7 @@ def trace_fweight(fimage, xinit_in, radius = 3.0, ycen=None, invvar=None):
     xnew = xinit.astype(float)
     xerr = np.full(ncen,999.)
 
-    if ycen == None:
+    if ycen is None:
         if ndim == 1:
             ycen = np.arange(npix, dtype='int')
         elif ndim == 2:

--- a/pypit/core/artraceslits.py
+++ b/pypit/core/artraceslits.py
@@ -2547,6 +2547,8 @@ def synchronize_edges(binarr, edgearr, plxbin, lmin, lmax, lcoeff, rmin, rcoeff,
 def trace_crude_init(image, xinit0, ypass, invvar=None, radius=2.,
     maxshift0=0.5, maxshift=0.15, maxerr=0.2):
     """Python port of trace_crude_idl.pro from IDLUTILS
+    #TODO this routine needs better docs. I'm also not sure why it is called trace_crude_init instead of just trace_crude.
+    #TODO Consistent naming with IDLUTILS makes it easier to figure out what rourine is what.
 
     Modified for initial guess
 
@@ -2578,7 +2580,7 @@ def trace_crude_init(image, xinit0, ypass, invvar=None, radius=2.,
     #  Recenter INITIAL Row for all traces simultaneously
     #
     iy = ypass * np.ones(ntrace,dtype=int)
-    xfit,xfiterr = trace_fweight(image, xinit, iy, invvar=invvar, radius=radius)
+    xfit,xfiterr = trace_fweight(image, xinit, ycen = iy, invvar=invvar, radius=radius)
     # Shift
     xshift = np.clip(xfit-xinit, -1*maxshift0, maxshift0) * (xfiterr < maxerr)
     xset[ypass,:] = xinit + xshift
@@ -2588,7 +2590,7 @@ def trace_crude_init(image, xinit0, ypass, invvar=None, radius=2.,
     for iy in range(ypass+1, ny):
         xinit = xset[iy-1, :]
         ycen = iy * np.ones(ntrace,dtype=int)
-        xfit,xfiterr = trace_fweight(image, xinit, ycen, invvar=invvar, radius=radius)
+        xfit,xfiterr = trace_fweight(image, xinit, ycen = ycen, invvar=invvar, radius=radius)
         # Shift
         xshift = np.clip(xfit-xinit, -1*maxshift, maxshift) * (xfiterr < maxerr)
         # Save
@@ -2598,7 +2600,7 @@ def trace_crude_init(image, xinit0, ypass, invvar=None, radius=2.,
     for iy in range(ypass-1, -1,-1):
         xinit = xset[iy+1, :]
         ycen = iy * np.ones(ntrace,dtype=int)
-        xfit,xfiterr = trace_fweight(image, xinit, ycen, invvar=invvar, radius=radius)
+        xfit,xfiterr = trace_fweight(image, xinit, ycen = ycen, invvar=invvar, radius=radius)
         # Shift
         xshift = np.clip(xfit-xinit, -1*maxshift, maxshift) * (xfiterr < maxerr)
         # Save

--- a/pypit/core/artracewave.py
+++ b/pypit/core/artracewave.py
@@ -171,6 +171,7 @@ def trace_tilt(ordcen, rordloc, lordloc, det, msarc, slitnum, settings_det,
     This function performs a PCA analysis on the arc tilts for a single spectrum (or order)
                tracethresh=1000.0, nsmth=0):
 
+    # TODO These docs are pathetic, please elaborate.
     Parameters
     ----------
     slf
@@ -204,6 +205,7 @@ def trace_tilt(ordcen, rordloc, lordloc, det, msarc, slitnum, settings_det,
 
     msgs.work("Detecting lines for slit {0:d}".format(slitnum+1))
     tampl, tcent, twid, w, _ = ararc.detect_lines(censpec)
+
     satval = settings_det['saturation']*settings_det['nonlinear']
     # Order of the polynomials to be used when fitting the tilts.
     arcdet = (tcent[w]+0.5).astype(np.int)

--- a/pypit/data/settings/settings.keck_nires
+++ b/pypit/data/settings/settings.keck_nires
@@ -1,0 +1,125 @@
+### Detector properties
+mosaic ndet 1                         # Number of detectors in the mosaic
+mosaic longitude 155.47833            # Longitude of the telescope (NOTE: West should correspond to positive longitudes)
+mosaic latitude 19.82833              # Latitude of the telescope
+mosaic elevation 4160.0               # Elevation of the telescope (in m)
+mosaic minexp 1.0                     # Minimum exposure time (s)
+mosaic reduction ARMS                 # Which reduction pipeline should be used for this instrument
+mosaic camera NIRES                   # Which reduction pipeline should be used for this instrument
+
+det01 xgap 0.0                        # Gap between the square detector pixels (expressed as a fraction of the x pixel size -- x is predominantly the dispersion axis)
+det01 ygap 0.0                        # Gap between the square detector pixels (expressed as a fraction of the y pixel size -- x is predominantly the dispersion axis)
+det01 ysize 1.0                       # The size of a pixel in the y-direction as a multiple of the x pixel size (i.e. xsize = 1.0 -- x is predominantly the dispersion axis)
+det01 darkcurr 0.01                    # Dark current (e-/hour)
+det01 platescale 0.123                # arcsec per pixel in the spatial dimension for an unbinned pixel, low-res mode; https://www2.keck.hawaii.edu/koa/public/nspec/nirspec_data_description.html
+det01 saturation 65535.0              # The detector Saturation level
+det01 nonlinear 0.76                  # Percentage of detector range which is linear (i.e. everything above nonlinear*saturation will be flagged as saturated)
+det01 numamplifiers 1                 # Number of amplifiers
+det01 gain 3.8                        # Gain (e-/ADU) values for the amplifier; https://www2.keck.hawaii.edu/inst/nirspec/Specifications.html
+# This number for ronoise is prelminary and should be measured
+det01 ronoise 2                       # RN (e-) for the amplifier
+det01 suffix None                     # Suffix to be appended to all saved calibration and extraction frames
+det01 dataext01 0                     # Extension number of the data
+det01 datasec01 [:,:]                 # Either the data sections or the header keyword where the valid data sections can be obtained
+det01 oscansec01 [:,:]                # Either the overscan sections or the header keyword where the valid overscan sections can be obtained
+
+### Checks to perform
+check 01.INSTRUME NIRES              # THIS IS A MUST! It checks the instrument
+check 01.NAXIS 2                       # THIS IS A MUST! It performs a standard check to make sure the data are 2D.
+check 01.NAXIS1 2048                   # Checks number of pixels in axis 1
+check 01.NAXIS2 1024                   # Checks number of pixels in axis 2
+#?check 02.CCDGEOM LBNL Thick High-Resistivity   # Check the CCD name (replace any spaces with underscores)
+#?check 02.CCDNAME 19-3                # Check the CCD name (replace any spaces with underscores)
+#?check 04.CCDNAME 19-2                # Check the CCD name (replace any spaces with underscores)
+
+### Keyword Identifiers
+keyword date 01.DATE-OBS
+keyword target 01.OBJECT               # Header keyword for the name given by the observer to a given frame
+keyword exptime 01.ELAPTIME            # Exposure time keyword; equals ITIME * COADDS
+keyword naxis0 01.NAXIS2               # Number of pixels along the zeroth axis;;;; which axis is "zeroth"??
+keyword naxis1 01.NAXIS1               # Number of pixels along the first axis
+keyword filter1 01.FILNAME             # Filter 1
+#keyword hatch 01.CALMPOS               # Cal. Mirror Position, 0=out, 1=in
+#keyword slitwid 01.SLITWIDT            # Slit width
+#keyword slitlen 01.SLITLEN             # Slit length
+#keyword lampname06 FLAT                # Name of a lamp
+#keyword lampstat06 01.FLAT             # Status of a lamp
+keyword dispname 01.DISPERS            # Grating name
+#keyword dispangle 01.GRANGLE           # Grating angle
+keyword imagetype 01.OBSTYPE          # KOA generated keyword for image type
+
+### Fits properties
+fits numhead 1                         # How many headers need to be read in for a given file
+fits headext01 0                       # Extension number of header (one for each headnum, starting with 01)
+fits numlamps 1                        # How many lamps are there listed in the header
+
+### Science frames
+science check condition1 imagetype=object # Check that KOA keyword is 'flatlamp'
+science check condition2 exptime>=20        # Required for a standard
+
+#science check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+#science check condition2 hatch=0       # Required for science; 0 is "out" for NIRES
+#science check condition3 exptime>=1    # Arbitrary exptime limit
+#science check condition4 imagetype=object # Check that KOA keyword is 'object'
+
+### Standard Star frames
+standard check condition1 imagetype=object # Check that KOA keyword is 'flatlamp'
+standard check condition2 exptime<=20        # Required for a standard
+
+#standard check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+#standard check condition2 hatch=0      # Required for standard; 0 is "out" for NIRSPEC
+#standard check condition3 imagetype=object # Check that KOA keyword is object
+#standard match dispname ''            # Check the same decker as the science frame was used
+#standard match dichroic ''            # Check the same decker as the science frame was used
+#standard match binning ''             # Match the shape of standard and science frames
+#standard match dispangle |<=0.02      # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Bias/Dark frames
+#bias check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+#bias check condition2 hatch=0          # Required for bias
+#bias check condition3 exptime<=1        # Required for bias
+#bias check condition4 imagetype=dark # Check that KOA keyword is 'dark'
+#bias match binning ''             	   # Match the shape of standard and science frames
+
+### Pixel Flat frames -- Dome Flat required
+pixelflat number 3                     # Number of flat frames to use
+pixelflat check condition1 imagetype=domeflat # Check that KOA keyword is 'flatlamp'
+
+#pixelflat check condition1 hatch=1     # Required for pixel flats;;;; hatch=1 for dome flats and arcs
+#pixelflat check condition2 exptime<30  # Avoid stars
+#pixelflat check condition3 lampstat06=1
+#pixelflat match binning ''            # Match the shape of standard and science frames
+#pixelflat match decker ''             # Check the same decker as the science frame was used
+#pixelflat match dichroic ''           # Check the same decker as the science frame was used
+#pixelflat match dispname ''           # Check the same decker as the science frame was used
+#pixelflat match dispangle |<=0.02     # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Pinhole frames
+#pinhole check condition1 exptime>999999 # Avoids any pinhole frames
+
+### Dark frames
+#dark check condition1 lampstat01=0&lampstat02=0&lampstat03=0&lampstat04=0&lampstat05=0&lampstat06=0
+#dark check condition2 exptime<5         # Avoids any dark frames
+#dark check condition3 imagetype=dark # Check that KOA keyword is 'dark'
+
+### Trace frames
+#trace check condition1 hatch=1         # Required for blaze flats;;;; hatch=1 for dome flats and arcs
+#trace check condition2 exptime<30      # Avoid stars
+#trace check condition3 lampstat06=1
+#trace match binning ''                # Match the shape of trace with science
+#trace match decker ''                 # Check the same decker as the science frame was used
+#trace match dichroic ''               # Check the same decker as the science frame was used
+#trace match dispname ''               # Check the same decker as the science frame was used
+#trace match dispangle |<=0.02         # Match the grating angle (no idea if this is reasonable for LRISr)
+
+### Arc frames
+#arc check condition1 lampstat01=1|lampstat02=1|lampstat03=1|lampstat04=1|lampstat05=1
+#arc check condition2 hatch=1           # Required for arcs; 1 = "in" = closed
+#arc check condition3 imagetype=arclamp # Check that KOA keyword is 'arclamp'
+#arc match binning ''                  # Match the shape of arcs with science
+#arc match dichroic ''                 # Check the same decker as the science frame was used
+#arc match dispname ''                 # Check the same decker as the science frame was used
+#arc match dispangle |<=0.02           # Match the grating angle (no idea if this is reasonable for LRISr)
+
+# Make some changes to the arguments and flags
+settings trace dispersion direction 1

--- a/pypit/ginga.py
+++ b/pypit/ginga.py
@@ -124,7 +124,7 @@ def show_slits(viewer, ch, lord_in, rord_in, slit_ids = None, rotate=False, pste
         lordloc = lord_in.reshape(lord_in.size,1)
         rordloc = rord_in.reshape(rord_in.size,1)
 
-    if slit_ids == None:
+    if np.any(slit_ids) == None:
         slit_ids = [str(slit) for slit in np.arange(nslit)]
 
     # Canvas

--- a/pypit/scienceimage.py
+++ b/pypit/scienceimage.py
@@ -403,6 +403,7 @@ class ScienceImage(processimages.ProcessImages):
             if slit not in gdslits:
                 self.tracelist.append({})
                 continue
+            msgs.info("Finding objects in slit: {}".format(slit))
             tlist = artrace.trace_objects_in_slit(self.det, slit, self.tslits_dict,
                                                   self.sciframe, self.global_sky,
                                                   varframe, self.crmask, self.settings)
@@ -455,7 +456,7 @@ class ScienceImage(processimages.ProcessImages):
             tracemask = None
 
         # Loop on slits
-        gdslits = [gdslits[-1]]
+        #gdslits = [gdslits[-1]]
         for slit in gdslits:
             msgs.info("Working on slit: {:d}".format(slit))
             # Find sky

--- a/pypit/scienceimage.py
+++ b/pypit/scienceimage.py
@@ -455,6 +455,7 @@ class ScienceImage(processimages.ProcessImages):
             tracemask = None
 
         # Loop on slits
+        gdslits = [gdslits[-1]]
         for slit in gdslits:
             msgs.info("Working on slit: {:d}".format(slit))
             # Find sky
@@ -462,8 +463,11 @@ class ScienceImage(processimages.ProcessImages):
                 slit+1, self.tslits_dict['slitpix'], self.tslits_dict['edge_mask'],
                 self.sciframe, varframe, self.tilts,
                 bpm=self.bpm, crmask=self.crmask, tracemask=tracemask)
-            # Add
-            self.global_sky += slit_bgframe
+            # Mask?
+            if np.sum(slit_bgframe) == 0.:
+                self.maskslits[slit] = True
+            else:
+                self.global_sky += slit_bgframe
 
         # Build model variance
         msgs.info("Building model variance from the Sky frame")

--- a/pypit/traceimage.py
+++ b/pypit/traceimage.py
@@ -19,7 +19,7 @@ if msgs._debug is None:
 # Does not need to be global, but I prefer it
 frametype = 'trace_image'
 
-
+# ToDO This syntax for instantiaion differs slightlhy from ArcIMage, and I think they need to be homogenized.
 class TraceImage(processimages.ProcessImages):
     """
     This class is primarily designed to generate a Bias frame for bias subtraction
@@ -44,6 +44,7 @@ class TraceImage(processimages.ProcessImages):
       Indices for bias frames (if a Bias image may be generated)
     fitstbl : Table (optional)
       FITS info (mainly for filenames)
+    #ToDO datasec_img is not documented!
 
     Attributes
     ----------

--- a/pypit/traceslits.py
+++ b/pypit/traceslits.py
@@ -155,6 +155,7 @@ class TraceSlits(masterframe.MasterFrame):
         self.lcen = None     # narray
         self.rcen = None     # narray
         self.tc_dict = None  # dict
+        # TODO Why is there a tc_dict and a tslits_dict. This is confusing naming without some docs or comments here.
         self.edgearr = None  # ndarray
         self.siglev = None   # ndarray
         self.steps = []
@@ -697,7 +698,7 @@ class TraceSlits(masterframe.MasterFrame):
         # Step
         self.steps.append(inspect.stack()[0][3])
 
-    def remove_slit(self, rm_slits):
+    def remove_slit(self, rm_slits, TOL = 3.):
         """
         Remove a user-specified slit
 
@@ -719,7 +720,7 @@ class TraceSlits(masterframe.MasterFrame):
 
         """
         self.edgearr, self.lcen, self.rcen, self.tc_dict = artraceslits.remove_slit(
-            self.edgearr, self.lcen, self.rcen, self.tc_dict, rm_slits)
+            self.edgearr, self.lcen, self.rcen, self.tc_dict, rm_slits, TOL=TOL)
         # Step
         self.steps.append(inspect.stack()[0][3])
 
@@ -815,7 +816,8 @@ class TraceSlits(masterframe.MasterFrame):
         # Step
         self.steps.append(inspect.stack()[0][3])
 
-    def show(self, attr='edges', display='ginga'):
+
+    def show(self, attr='edges', pstep=50):
         """
         Display an image or spectrum in TraceSlits
 
@@ -831,7 +833,7 @@ class TraceSlits(masterframe.MasterFrame):
         if attr == 'edges':
             viewer, ch = ginga.show_image(self.mstrace)
             if self.lcen is not None:
-                ginga.show_slits(viewer, ch, self.lcen, self.rcen, np.arange(self.lcen.shape[1]) + 1, pstep=50)
+                ginga.show_slits(viewer, ch, self.lcen, self.rcen, slit_ids = np.arange(self.lcen.shape[1]) + 1, pstep=pstep)
         elif attr == 'edgearr':
             # TODO -- Figure out how to set the cut levels
             debugger.show_image(self.edgearr)

--- a/pypit/wavetilts.py
+++ b/pypit/wavetilts.py
@@ -411,7 +411,7 @@ class WaveTilts(masterframe.MasterFrame):
         attr : str
           'fweight' -- Show the msarc image and the tilts traced by fweight
           'model' -- Show the msarc image and the tilts traced by fweight
-          'tilts' -- Show the msarc image and the tilts traced by fweight
+          'tilts_img' -- Show the msarc image and the tilts traced by fweight
           'final_tilts' -- Show the msarc image and the tilts traced by fweight
         slit : int, optional
         display : str (optional)

--- a/pypit/wavetilts.py
+++ b/pypit/wavetilts.py
@@ -255,11 +255,19 @@ class WaveTilts(masterframe.MasterFrame):
 
         """
         # Determine the tilts for this slit
+        tracethresh_in = self.settings['tilts']['tracethresh']
+        if isinstance(tracethresh_in,float) | isinstance(tracethresh_in,int):
+            tracethresh = tracethresh_in
+        elif isinstance(tracethresh_in, list) | isinstance(tracethresh_in, np.ndarray):
+            tracethresh = tracethresh_in[slit]
+        else:
+            raise ValueError('Invalid input for parameter tracethresh')
+
         trcdict = artracewave.trace_tilt(self.tslits_dict['pixcen'], self.tslits_dict['lcen'],
                                          self.tslits_dict['rcen'], self.det,
                                          self.msarc, slit, self.settings_det, self.settings,
                                          censpec=self.arccen[:, slit], nsmth=3,
-                                         tracethresh=self.settings['tilts']['tracethresh'],
+                                         tracethresh=tracethresh,
                                          wv_calib=wv_calib)
         # Load up
         self.all_trcdict[slit] = trcdict.copy()


### PR DESCRIPTION
This is a reasonably sized pull request that involves changes resulting from trying to make the master branch more compatible with upcoming implementation of revamped object finding and extraction. 

We also add the functionality to allow for wavetilts to take different line tracing thresholds for different orders/slits. This is implemented via optionally making one of the settings a list rather than a float. It will run correctly either way. 

Other fixes to extraction related to differences in PYPIT read noise image definition (rn2 rather than rn) have been implemented as these were bugs in the first version of the extraction algorithms. 

